### PR TITLE
Feat/example hatters

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -551,7 +551,6 @@ contract Hats is ERC1155 {
     /// @notice View the properties of a given Hat
     /// @param _hatId The id of the Hat
     /// @return details The details of the Hat
-    /// @return id The id of the Hat
     /// @return maxSupply The max supply of tokens for this Hat
     /// @return supply The number of current wearers of this Hat
     /// @return oracle The Oracle address for this Hat
@@ -562,7 +561,6 @@ contract Hats is ERC1155 {
         view
         returns (
             string memory details,
-            uint256 id,
             uint32 maxSupply,
             uint32 supply,
             address oracle,
@@ -572,7 +570,6 @@ contract Hats is ERC1155 {
     {
         Hat memory hat = hats[_hatId];
         details = hat.details;
-        id = _hatId;
         maxSupply = hat.maxSupply;
         supply = hatSupply[_hatId];
         oracle = hat.oracle;

--- a/src/HatsAdmins/SampleHatter.sol
+++ b/src/HatsAdmins/SampleHatter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity >=0.8.13;
+
+import "../HatsOracles/IHatsOracle.sol";
+import "../IHats.sol";
+import "solmate/auth/Auth.sol";
+
+/// @notice designed to serve as the admin for multiple hats
+abstract contract SampleMultiHatter is Auth {
+    IHats public HATS;
+
+    constructor(address _hatsContract) {
+        HATS = IHats(_hatsContract);
+    }
+
+    // DAO governance mint function (auth)
+    function mint(uint256 _hatId, address _wearer) public virtual requiresAuth {
+        _mint(_hatId, _wearer);
+    }
+
+    function _mint(uint256 _hatId, address _wearer) internal virtual {
+        require(HATS.isInGoodStanding(_wearer, _hatId), "not eligible");
+        HATS.mintHat(_hatId, _wearer);
+    }
+
+    function createAndMint(
+        uint256 _admin,
+        string memory _details,
+        uint32 _maxSupply,
+        address _oracle,
+        address _conditions,
+        address _wearer
+    ) public virtual requiresAuth {
+        uint256 id = HATS.createHat(
+            _admin,
+            _details,
+            _maxSupply,
+            _oracle,
+            _conditions
+        );
+        _mint(id, _wearer);
+    }
+
+    // DAO governance transfer function (auth)
+    function transfer(
+        uint256 _hatId,
+        address _wearer,
+        address _newWearer
+    ) public virtual requiresAuth {
+        HATS.transferHat(_hatId, _wearer, _newWearer);
+    }
+
+    function batchTransfer(
+        uint256[] memory _hatIds,
+        address[] memory _wearers,
+        address[] memory _newWearers
+    ) public virtual requiresAuth {
+        HATS.batchTransferHats(_hatIds, _wearers, _newWearers);
+    }
+}

--- a/src/IHats.sol
+++ b/src/IHats.sol
@@ -3,25 +3,85 @@ pragma solidity >=0.8.13;
 
 interface IHats {
     function createHat(
+        uint256 admin,
         string memory details, // encode as bytes32 ??
         uint32 maxSupply,
         address oracle,
         address conditions
     ) external returns (uint256 hatId);
 
-    // function recordOffer(
-    //     uint256 hatId,
-    //     address offeror,
-    //     uint256 amount
-    // ) external returns (uint256 offerId);
+    function mintHat(uint256 _hatId, address _wearer) external returns (bool);
 
-    // function acceptOffer(uint256 offerId) external returns (bool);
+    function batchMintHats(uint256[] memory _hatIds, address[] memory _wearers)
+        external
+        returns (bool);
 
     function getHatStatus(uint256 hatId) external returns (bool);
 
-    function setHatStatus(uint256 hatId, bool newStatus) external returns (bool);
+    function setHatStatus(uint256 hatId, bool newStatus)
+        external
+        returns (bool);
 
-    function getHatWearerStatus(uint256 hatId, address wearer) external returns (bool);
+    function getHatWearerStatus(uint256 hatId, address wearer)
+        external
+        returns (bool);
 
-    function setHatWearerStatus(uint256 hatId, address wearer, bool revoke, bool wearerStanding) external returns (bool);
+    function setHatWearerStatus(
+        uint256 hatId,
+        address wearer,
+        bool revoke,
+        bool wearerStanding
+    ) external returns (bool);
+
+    function renounceHat(uint256 _hatId) external;
+
+    function transferHat(
+        uint256 _hatId,
+        address _from,
+        address _to
+    ) external;
+
+    function batchTransferHats(
+        uint256[] memory _hatIds,
+        address[] memory _froms,
+        address[] memory _tos
+    ) external;
+
+    function viewHat(uint256 _hatId)
+        external
+        view
+        returns (
+            string memory details,
+            uint32 maxSupply,
+            uint32 supply,
+            address oracle,
+            address conditions,
+            bool active
+        );
+
+    function isTopHat(uint256 _hatId) external pure returns (bool);
+
+    function isWearerOfHat(address _user, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function isAdminOfHat(address _user, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function getHatLevel(uint256 _hatId) external pure returns (uint8 level);
+
+    function isActive(uint256 _hatId) external view returns (bool);
+
+    function isInGoodStanding(address _wearer, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function balanceOf(address wearer, uint256 hatId)
+        external
+        view
+        returns (uint256 balance);
 }


### PR DESCRIPTION
- adds sample hatter contract (admin) functions -- #26 
- fleshes out IHats interface
- simplifies `viewHat` but removing redundent `id` from the returned objects