### PR TITLE
Feat/generalized oracle

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -348,7 +348,7 @@ contract Hats is ERC1155 {
     /// @dev The msg.sender must be set as the hat's Conditions
     /// @param _hatId The id of the Hat for which to adjust status
     /// @return bool Whether the status was toggled
-    function changeHatStatus(uint256 _hatId, bool newStatus)
+    function setHatStatus(uint256 _hatId, bool newStatus)
         external
         returns (bool)
     {
@@ -369,14 +369,14 @@ contract Hats is ERC1155 {
     /// @dev // TODO
     /// @param _hatId The id of the Hat whose Conditions we are checking
     /// @return bool Whether the check succeeded
-    function checkConditions(uint256 _hatId) external returns (bool) {
+    function getHatStatus(uint256 _hatId) external returns (bool) {
         Hat storage hat = hats[_hatId];
 
         IHatsConditions CONDITIONS = IHatsConditions(hat.conditions);
 
-        // FIXME what happens if CONDITIONS doesn't have a checkConditions() function?
+        // FIXME what happens if CONDITIONS doesn't have a getHatStatus() function?
         // likely answer: the whole thing reverts, which is actually what we want
-        bool newStatus = CONDITIONS.checkConditions(_hatId);
+        bool newStatus = CONDITIONS.getHatStatus(_hatId);
 
         if (newStatus != hat.active) {
             hat.active = newStatus;
@@ -679,9 +679,7 @@ contract Hats is ERC1155 {
     {
         IHatsConditions CONDITIONS = IHatsConditions(_hat.conditions);
 
-        return (CONDITIONS.checkConditions(_hatId) && _hat.active);
-
-        try CONDITIONS.checkConditions(_hatId) returns (bool status_) {
+        try CONDITIONS.getHatStatus(_hatId) returns (bool status_) {
             active = status_;
         } catch {
             // if the external call reverts, default to the existing state

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -551,7 +551,6 @@ contract Hats is ERC1155 {
     /// @notice View the properties of a given Hat
     /// @param _hatId The id of the Hat
     /// @return details The details of the Hat
-    /// @return id The id of the Hat
     /// @return maxSupply The max supply of tokens for this Hat
     /// @return supply The number of current wearers of this Hat
     /// @return oracle The Oracle address for this Hat
@@ -562,7 +561,6 @@ contract Hats is ERC1155 {
         view
         returns (
             string memory details,
-            uint256 id,
             uint32 maxSupply,
             uint32 supply,
             address oracle,
@@ -572,7 +570,6 @@ contract Hats is ERC1155 {
     {
         Hat memory hat = hats[_hatId];
         details = hat.details;
-        id = _hatId;
         maxSupply = hat.maxSupply;
         supply = hatSupply[_hatId];
         oracle = hat.oracle;

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -37,7 +37,7 @@ contract Hats is ERC1155 {
         // 1st storage slot
         address oracle; // can revoke Hat based on ruling; 20 bytes (+20)
         uint32 maxSupply; // the max number of identical hats that can exist; 24 bytes (+4)
-        bool active; // can be altered by conditions, via deactivateHat(); 25 bytes (+1)
+        bool active; // can be altered by conditions, via setHatStatus(); 25 bytes (+1)
         uint8 lastHatId; // indexes how many different hats an admin is holding; 26 bytes (+1)
         // 2nd storage slot
         address conditions; // controls when Hat is active; 20 bytes (+20)

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -272,33 +272,34 @@ contract Hats is ERC1155 {
         return _admin | uint256(nextHatId);
     }
 
-    /// @notice Creates a tree new Hats, where the root Hat is under admin control by the msg.sender. Especially useful for forking an existing Hat tree or initiating a template Hat tree structure.
-    /// @dev The admin for each Hat must exist before the Hat is created, so Hats must be created before Hats for which they serve as admin
-    /// @param _details Descriptions of the Hats
-    /// @param _maxSupplies The total instances of the Hats that can be worn at once
-    /// @param _firstAdmin The hatId of the admin of the first Hat to create; it must already exist
-    /// @param _oracles The addresses that can report on the Hat wearers' status
-    /// @param _conditions The addresses that can deactivate the Hats
-    function createHatsTree(
-        string[] memory _details,
-        uint32[] memory _maxSupplies,
-        uint256 _firstAdmin,
-        address[] memory _oracles,
-        address[] memory _conditions
-    ) public {
-        // check that array lengths match
-        uint256 length = _maxSupplies.length; // saves an MLOAD
+    // TODO reimplement createHatsTree post-mvp
+    // /// @notice Creates a tree new Hats, where the root Hat is under admin control by the msg.sender. Especially useful for forking an existing Hat tree or initiating a template Hat tree structure.
+    // /// @dev The admin for each Hat must exist before the Hat is created, so Hats must be created before Hats for which they serve as admin
+    // /// @param _details Descriptions of the Hats
+    // /// @param _maxSupplies The total instances of the Hats that can be worn at once
+    // /// @param _firstAdmin The hatId of the admin of the first Hat to create; it must already exist
+    // /// @param _oracles The addresses that can report on the Hat wearers' status
+    // /// @param _conditions The addresses that can deactivate the Hats
+    // function createHatsTree(
+    //     string[] memory _details,
+    //     uint32[] memory _maxSupplies,
+    //     uint256 _firstAdmin,
+    //     address[] memory _oracles,
+    //     address[] memory _conditions
+    // ) public {
+    //     // check that array lengths match
+    //     uint256 length = _maxSupplies.length; // saves an MLOAD
 
-        bool lengthsCheck = ((_details.length == length) &&
-            (length == _oracles.length) &&
-            (length == _conditions.length));
+    //     bool lengthsCheck = ((_details.length == length) &&
+    //         (length == _oracles.length) &&
+    //         (length == _conditions.length));
 
-        if (!lengthsCheck) {
-            revert BatchArrayLengthMismatch();
-        }
+    //     if (!lengthsCheck) {
+    //         revert BatchArrayLengthMismatch();
+    //     }
 
-        // TODO reimplement
-    }
+    //
+    // }
 
     /// @notice Mints an ERC1155 token of the Hat to a recipient, who then "wears" the hat
     /// @dev The msg.sender must wear the admin Hat of `_hatId`
@@ -519,9 +520,9 @@ contract Hats is ERC1155 {
             revert NotHatWearer();
         }
 
-        //TODO Adjust balances
-        //--_balanceOf[_from][id];
-        //++_balanceOf[_to][id];
+        //Adjust balances
+        --_balanceOf[_from][id];
+        ++_balanceOf[_to][id];
 
         emit TransferSingle(msg.sender, _from, _to, id, 1);
     }
@@ -817,7 +818,7 @@ contract Hats is ERC1155 {
         uint256 amount,
         bytes memory data
     ) internal override {
-        //_balanceOf[to][id] += amount;
+        _balanceOf[to][id] += amount;
 
         // increment Hat supply counter
         ++hatSupply[uint256(id)];

--- a/src/HatsAdmins/SampleHatter.sol
+++ b/src/HatsAdmins/SampleHatter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity >=0.8.13;
+
+import "../HatsOracles/IHatsOracle.sol";
+import "../IHats.sol";
+import "solmate/auth/Auth.sol";
+
+/// @notice designed to serve as the admin for multiple hats
+abstract contract SampleMultiHatter is Auth {
+    IHats public HATS;
+
+    constructor(address _hatsContract) {
+        HATS = IHats(_hatsContract);
+    }
+
+    // DAO governance mint function (auth)
+    function mint(uint256 _hatId, address _wearer) public virtual requiresAuth {
+        _mint(_hatId, _wearer);
+    }
+
+    function _mint(uint256 _hatId, address _wearer) internal virtual {
+        require(HATS.isInGoodStanding(_wearer, _hatId), "not eligible");
+        HATS.mintHat(_hatId, _wearer);
+    }
+
+    function createAndMint(
+        uint256 _admin,
+        string memory _details,
+        uint32 _maxSupply,
+        address _oracle,
+        address _conditions,
+        address _wearer
+    ) public virtual requiresAuth {
+        uint256 id = HATS.createHat(
+            _admin,
+            _details,
+            _maxSupply,
+            _oracle,
+            _conditions
+        );
+        _mint(id, _wearer);
+    }
+
+    // DAO governance transfer function (auth)
+    function transfer(
+        uint256 _hatId,
+        address _wearer,
+        address _newWearer
+    ) public virtual requiresAuth {
+        HATS.transferHat(_hatId, _wearer, _newWearer);
+    }
+
+    function batchTransfer(
+        uint256[] memory _hatIds,
+        address[] memory _wearers,
+        address[] memory _newWearers
+    ) public virtual requiresAuth {
+        HATS.batchTransferHats(_hatIds, _wearers, _newWearers);
+    }
+}

--- a/src/HatsConditions/IHatsConditions.sol
+++ b/src/HatsConditions/IHatsConditions.sol
@@ -3,5 +3,5 @@
 pragma solidity >=0.8.13;
 
 interface IHatsConditions {
-    function checkConditions(uint256 _hatId) external view returns (bool);
+    function getHatStatus(uint256 _hatId) external view returns (bool);
 }

--- a/src/HatsConditions/SampleHatsConditions.sol
+++ b/src/HatsConditions/SampleHatsConditions.sol
@@ -13,7 +13,7 @@ abstract contract ExpiringHatsConditions is IHatsConditions {
 
     mapping(uint256 => uint256) public expiries; // key: hatId => value: expiry timestamp
 
-    function checkConditions(uint256 _hatId)
+    function getHatStatus(uint256 _hatId)
         public
         view
         virtual
@@ -44,7 +44,7 @@ abstract contract OwnableHatsConditions is IHatsConditions, Auth {
         HATS = IHats(_hatsContract);
     }
 
-    function checkConditions(uint256 _hatId)
+    function getHatStatus(uint256 _hatId)
         public
         view
         virtual
@@ -53,7 +53,7 @@ abstract contract OwnableHatsConditions is IHatsConditions, Auth {
         return (status[_hatId]);
     }
 
-    function setStatus(uint256 _hatId, bool _status)
+    function setHatStatus(uint256 _hatId, bool _status)
         public
         virtual
         requiresAuth
@@ -65,6 +65,6 @@ abstract contract OwnableHatsConditions is IHatsConditions, Auth {
     }
 
     function _updateHatStatus(uint256 _hatId, bool _status) internal virtual {
-        HATS.changeHatStatus(_hatId, _status);
+        HATS.setHatStatus(_hatId, _status);
     }
 }

--- a/src/HatsOracles/IHatsOracle.sol
+++ b/src/HatsOracles/IHatsOracle.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.8.13;
 
 interface IHatsOracle {
-    function checkWearerStanding(address _wearer, uint256 _hatId)
+    function getWearerStatus(address _wearer, uint256 _hatId)
         external
         view
-        returns (bool);
+        returns (bool, bool);
 }

--- a/src/HatsOracles/SampleHatsOracle.sol
+++ b/src/HatsOracles/SampleHatsOracle.sol
@@ -6,83 +6,40 @@ import "./IHatsOracle.sol";
 import "../IHats.sol";
 import "solmate/auth/Auth.sol";
 
-abstract contract ExpiringHatsOracle is IHatsOracle {
-    event HatTokenExpirySet(address _wearer, uint256 _hatId, uint256 _expiry);
-
-    error TokenExpiryInPast();
-
-    IHats public HATS;
-
-    constructor(address _hatsContract) {
-        HATS = IHats(_hatsContract);
-    }
-
-    // key1: wearer => key2: hatId => value: token expiry timestamp
-    mapping(address => mapping(uint256 => uint256)) public tokenExpiries;
-
-    function ruleOnWearerStanding(address _wearer, uint64 _hatId)
-        external
-        virtual
-    {
-        bool ruling = checkWearerStanding(_wearer, _hatId);
-
-        HATS.ruleOnHatWearerStanding(_hatId, _wearer, ruling);
-    }
-
-    function checkWearerStanding(address _wearer, uint64 _hatId)
-        public
-        view
-        returns (bool)
-    {
-        return (block.timestamp < tokenExpiries[_wearer][_hatId]);
-    }
-
-    function setTokenExpiry(address _wearer, uint256 _hatId, uint256 _expiry) public virtual {
-        if (block.timestamp > _expiry) {
-            revert TokenExpiryInPast();
-        }
-
-        tokenExpiries[_wearer][_hatId] = _expiry;
-
-        emit HatTokenExpirySet(_wearer, _hatId, _expiry);
-    }
-}
-
 abstract contract OwnableHatsOracle is IHats, IHatsOracle, Auth {
-    event HatStandingSet(address _wearer, uint256 _hatId, bool _standing);
+    event HatStandingSet(address _wearer, uint256 _hatId, bool _revoke, bool _standing);
 
     IHats public HATS;
 
-    mapping(address => mapping(uint256 => bool)) public standing;
+    mapping(address => mapping(uint256 => bool)) public standings;
 
     constructor(address _hatsContract) {
         HATS = IHats(_hatsContract);
     }
 
-    // do we want to standardize this function / add to the interface?
-    function _ruleOnWearerStanding(address _wearer, uint256 _hatId, bool _ruling)
-        internal
-        virtual
-    {
-        HATS.ruleOnHatWearerStanding(_hatId, _wearer, _ruling);
-    }
-
-    function checkWearerStanding(address _wearer, uint64 _hatId)
+    function getWearerStatus(address _wearer, uint64 _hatId)
         public
         view
         returns (bool)
     {
-        return standing[_wearer][_hatId];
+        return standings[_wearer][_hatId];
     }
 
-    function setStanding(address _wearer, uint256 _hatId, bool _standing)
+    function setWearerStatus(address _wearer, uint256 _hatId, bool _revoke, bool _standing)
         public
         virtual
         requiresAuth
     {
-        standing[_wearer][_hatId] = _standing;
-        _ruleOnWearerStanding(_wearer, _hatId, _standing);
+        standings[_wearer][_hatId] = _standing;
+        _updateHatWearerStatus(_wearer, _hatId, _revoke, _standing);
 
-        emit HatStandingSet(_wearer, _hatId, _standing);
+        emit HatStandingSet(_wearer, _hatId, _revoke, _standing);
+    }
+
+    function _updateHatWearerStatus(address _wearer, uint256 _hatId, bool _revoke, bool _standing)
+        internal
+        virtual
+    {
+        HATS.setHatWearerStatus(_hatId, _wearer, _revoke, _standing);
     }
 }

--- a/src/IHats.sol
+++ b/src/IHats.sol
@@ -3,25 +3,85 @@ pragma solidity >=0.8.13;
 
 interface IHats {
     function createHat(
+        uint256 admin,
         string memory details, // encode as bytes32 ??
         uint32 maxSupply,
         address oracle,
         address conditions
     ) external returns (uint256 hatId);
 
-    // function recordOffer(
-    //     uint256 hatId,
-    //     address offeror,
-    //     uint256 amount
-    // ) external returns (uint256 offerId);
+    function mintHat(uint256 _hatId, address _wearer) external returns (bool);
 
-    // function acceptOffer(uint256 offerId) external returns (bool);
+    function batchMintHats(uint256[] memory _hatIds, address[] memory _wearers)
+        external
+        returns (bool);
 
     function getHatStatus(uint256 hatId) external returns (bool);
 
-    function setHatStatus(uint256 hatId, bool newStatus) external returns (bool);
+    function setHatStatus(uint256 hatId, bool newStatus)
+        external
+        returns (bool);
 
-    function getHatWearerStatus(uint256 hatId, address wearer) external returns (bool);
+    function getHatWearerStatus(uint256 hatId, address wearer)
+        external
+        returns (bool);
 
-    function setHatWearerStatus(uint256 hatId, address wearer, bool revoke, bool wearerStanding) external returns (bool);
+    function setHatWearerStatus(
+        uint256 hatId,
+        address wearer,
+        bool revoke,
+        bool wearerStanding
+    ) external returns (bool);
+
+    function renounceHat(uint256 _hatId) external;
+
+    function transferHat(
+        uint256 _hatId,
+        address _from,
+        address _to
+    ) external;
+
+    function batchTransferHats(
+        uint256[] memory _hatIds,
+        address[] memory _froms,
+        address[] memory _tos
+    ) external;
+
+    function viewHat(uint256 _hatId)
+        external
+        view
+        returns (
+            string memory details,
+            uint32 maxSupply,
+            uint32 supply,
+            address oracle,
+            address conditions,
+            bool active
+        );
+
+    function isTopHat(uint256 _hatId) external pure returns (bool);
+
+    function isWearerOfHat(address _user, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function isAdminOfHat(address _user, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function getHatLevel(uint256 _hatId) external pure returns (uint8 level);
+
+    function isActive(uint256 _hatId) external view returns (bool);
+
+    function isInGoodStanding(address _wearer, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function balanceOf(address wearer, uint256 hatId)
+        external
+        view
+        returns (uint256 balance);
 }

--- a/src/IHats.sol
+++ b/src/IHats.sol
@@ -3,33 +3,25 @@ pragma solidity >=0.8.13;
 
 interface IHats {
     function createHat(
-        string memory name, // encode as bytes32 ??
         string memory details, // encode as bytes32 ??
-        uint256 eligibilityThreshold,
-        address owner,
+        uint32 maxSupply,
         address oracle,
         address conditions
     ) external returns (uint256 hatId);
 
-    function recordOffer(
-        uint256 hatId,
-        address offeror,
-        uint256 amount
-    ) external returns (uint256 offerId);
+    // function recordOffer(
+    //     uint256 hatId,
+    //     address offeror,
+    //     uint256 amount
+    // ) external returns (uint256 offerId);
 
-    function acceptOffer(uint256 offerId) external returns (bool);
+    // function acceptOffer(uint256 offerId) external returns (bool);
 
-    function checkHatConditions(uint256 hatId) external returns (bool);
+    function getHatStatus(uint256 hatId) external returns (bool);
 
-    function deactivateHat(uint256 hatId) external returns (bool);
+    function setHatStatus(uint256 hatId, bool newStatus) external returns (bool);
 
-    function requestOracleRuling(uint256 hatId) external returns (bool);
+    function getHatWearerStatus(uint256 hatId, address wearer) external returns (bool);
 
-    function ruleOnHatWearerStanding(uint256 hatId, address wearer, bool ruling) external returns (bool);
-
-    function changeHatStatus(uint256 hatId, bool newStatus) external returns (bool);
-
-    function recordRelinquishment(uint256 hatId, address wearer)
-        external
-        returns (bool success, uint256 amount);
+    function setHatWearerStatus(uint256 hatId, address wearer, bool revoke, bool wearerStanding) external returns (bool);
 }


### PR DESCRIPTION
- rename several functions, variables, events (
  - function deactivateHat -> setHatStatus
  - function checkConditions -> getHatStatus
  - function ruleOnHatWearerStanding -> setHatWearerStatus
  - function checkHatWearerStanding -> getHatWearerStatus
  - mapping revocations -> badStandings
  - event Ruling -> WearerStatus

- add Sample contracts for Hatter (admin), Oracle, and Conditions. We expect that most DAOs will start using Hats by setting the DAO's address itself as the admin, oracle, and conditions. However, these can be used and extended by DAOs for mechanistic / algorithmic implementations of this functionality. 

- note: createHatsTree is no longer functional, will be reimplemented after MVP