### PR TITLE
Add support for hat-specific imageURIs (re-creating PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The wearer of a hat can "take off" their Hat via `Hats.renounceHat`. This burns 
 
 Each hat can be created to include an image URI, which points to media for apps to display along with the hat token.
 
-If the image URI for a given hat was not unspecified upon hat creation, the image URI for that hat defaults to the URI specified for it's admin hat. This fallback happens recursively, traversing the hat's tree of admins until a specified URI is found. If there is no specified URI within that tree of admins, the image URI defaults to the global `_baseImageURI`.
+If the image URI for a given hat was not specified upon hat creation, the image URI for that hat defaults to the URI specified for it's admin hat. This fallback happens recursively, traversing the hat's tree of admins until a specified URI is found. If there is no specified URI within that tree of admins, the image URI defaults to the global `_baseImageURI`.
 
 This architecture allows DAOs and other hat creators to add custom images to their organization's hats without requiring them to do so. There is no additional gas cost imposed on hat creators choosing not to specify a custom image URI.
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Hat admins are the one exception to the rule that authorities are external to th
 Each Hat has several properties:
 
 - `id` - the integer identifier for the Hat, which also serves as the ERC1155 token id (see three paragraphs below)
-- `details` - metadata about the Hat; such as a name, description, and other properties like roles and responsibilities associated with the Hat
+- `details` - (optional) metadata about the Hat; such as a name, description, and other properties like roles and responsibilities associated with the Hat
 - `maxSupply` - the maximum number of addresses that can wear the Hat at once
 - `admin` - the Hat that controls who can wear the Hat
 - `oracle` - the address that controls whether a given wearer of the Hat is in good standing
 - `conditions` - the address that controls whether the Hat is active
+- `imageURI` - (optional) a uri pointing to an image for front ends to display for this hat
 
 For more information on each property, refer to the detailed sections below.
 
@@ -192,7 +193,23 @@ Since batch Hats transfers can be made from and to multiple wearers, batch trans
 
 ### Renouncing a Hat
 
-The wearer of a Hat can "take off" their Hat via `Hats.renounceHat`. This burns the token and revokes any associated authorities and responsibilities, but does not record a revocation.
+The wearer of a hat can "take off" their Hat via `Hats.renounceHat`. This burns the token and revokes any associated authorities and responsibilities, but does not record a revocation.
+
+### Image URIs
+
+Each hat can be created to include an image URI, which points to media for apps to display along with the hat token.
+
+If the image URI for a given hat was not unspecified upon hat creation, the image URI for that hat defaults to the URI specified for it's admin hat. This fallback happens recursively, traversing the hat's tree of admins until a specified URI is found. If there is no specified URI within that tree of admins, the image URI defaults to the global `_baseImageURI`.
+
+This architecture allows DAOs and other hat creators to add custom images to their organization's hats without requiring them to do so. There is no additional gas cost imposed on hat creators choosing not to specify a custom image URI.
+
+#### Image URIs and Hat Ids
+
+The structure of the URI returned by the `uri` function for a given hat depends on whether the hat had a custom image URI specified when it was created.
+
+For hats that *did* have an image URI specificed, the returned URI will be the concatenation of the specified image URI and the id "0". The assumption is that this is the most senior (lowest level) hat that has this URI. Returned URIs for all children of this hat that do not have their own specified image URI will follow the below convention.
+
+For hats that *did not* have an image URI specified, the returned URI will be the concatenation of its nearest admin's specified URI and its own hat id. This is required to avoid collisions with other hats that may also be children of the nearest admin.
 
 ## Latest Deployments
 

--- a/script/Hats.s.sol
+++ b/script/Hats.s.sol
@@ -12,7 +12,7 @@ contract DeployHats is Script {
 
         string memory name = "Hats Protocol - Beta 1"; // increment this each test deployment
 
-        Hats hats = new Hats(imageURIname);
+        Hats hats = new Hats(name, imageURI);
 
         vm.stopBroadcast();
     }

--- a/script/Hats.s.sol
+++ b/script/Hats.s.sol
@@ -5,12 +5,14 @@ import "forge-std/Script.sol";
 import "../src/Hats.sol";
 
 contract DeployHats is Script {
+    string public imageURI = "mvp:";
+
     function run() external {
         vm.startBroadcast();
 
         string memory name = "Hats Protocol - Beta 1"; // increment this each test deployment
 
-        Hats hats = new Hats(name);
+        Hats hats = new Hats(imageURIname);
 
         vm.stopBroadcast();
     }

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -101,7 +101,7 @@ contract Hats is ERC1155 {
 
     event HatStatusChanged(uint256 hatId, bool newStatus);
 
-    constructor(string memory _base, string memory ImageURI) {
+    constructor(string memory _name, string memory _baseImageURI) {
         name = _name;
         baseImageURI = _baseImageURI;
     }

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -324,8 +324,6 @@ contract Hats is ERC1155 {
         return true;
     }
 
-    function changeHatImageURI(uint256 _hatId, string memory _newURI)
-
     /// @notice Toggles a Hat's status from active to deactive, or vice versa
     /// @dev The msg.sender must be set as the hat's Conditions
     /// @param _hatId The id of the Hat for which to adjust status
@@ -778,7 +776,7 @@ contract Hats is ERC1155 {
             return string.concat(imageURI, "0");
         }
 
-        // if _hatId doesn't have an imageURI, we fall back to its admin treep
+        // if _hatId doesn't have an imageURI, we fall back to its admin tree
         uint256 level = getHatLevel(_hatId);
 
         // already checked at `level`, so we start the loop at `level - 1`

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -324,6 +324,8 @@ contract Hats is ERC1155 {
         return true;
     }
 
+    function changeHatImageURI(uint256 _hatId, string memory _newURI)
+
     /// @notice Toggles a Hat's status from active to deactive, or vice versa
     /// @dev The msg.sender must be set as the hat's Conditions
     /// @param _hatId The id of the Hat for which to adjust status

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -47,6 +47,8 @@ contract Hats is ERC1155 {
         address conditions; // controls when Hat is active; 20 bytes (+20)
         // 3rd+ storage slot
         string details;
+        // optional
+        string imageURI;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -56,6 +58,8 @@ contract Hats is ERC1155 {
     string public name;
 
     uint32 public lastTopHatId; // initialized at 0
+
+    string public baseImageURI;
 
     /**
      * Hat IDs act like addresses. The top level consists of 4 bytes and references all tophats
@@ -67,8 +71,6 @@ contract Hats is ERC1155 {
      *
      */
     mapping(uint256 => Hat) internal _hats;
-
-    // string public baseImageURI = "https://images.hatsprotocol.xyz/"
 
     mapping(uint256 => uint32) public hatSupply; // key: hatId => value: supply
 
@@ -84,7 +86,8 @@ contract Hats is ERC1155 {
         string details,
         uint32 maxSupply,
         address oracle,
-        address conditions
+        address conditions,
+        string imageURI
     );
 
     event HatRenounced(uint256 hatId, address wearer);
@@ -98,8 +101,9 @@ contract Hats is ERC1155 {
 
     event HatStatusChanged(uint256 hatId, bool newStatus);
 
-    constructor(string memory _name) {
+    constructor(string memory _base, string memory ImageURI) {
         name = _name;
+        baseImageURI = _baseImageURI;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -109,8 +113,13 @@ contract Hats is ERC1155 {
     /// @notice Creates and mints a Hat that is its own admin, i.e. a "topHat"
     /// @dev A topHat has no oracle and no conditions
     /// @param _target The address to which the newly created topHat is minted
+    /// @param _imageURI The image uri for this top hat and the fallback for its
+    ///                  children hats [optional]
     /// @return topHatId The id of the newly created topHat
-    function mintTopHat(address _target) public returns (uint256 topHatId) {
+    function mintTopHat(address _target, string memory _imageURI)
+        public
+        returns (uint256 topHatId)
+    {
         // create hat
 
         topHatId = uint256(++lastTopHatId) << 224;
@@ -120,7 +129,8 @@ contract Hats is ERC1155 {
             "", // details
             1, // maxSupply = 1
             address(0), // there is no oracle
-            address(0) // it has no conditions
+            address(0), // it has no conditions
+            _imageURI
         );
 
         _mint(_target, topHatId, 1, "");
@@ -130,23 +140,30 @@ contract Hats is ERC1155 {
     /// @param _details A description of the hat
     /// @param _maxSupply The total instances of the Hat that can be worn at once
     /// @param _oracle The address that can report on the Hat wearer's standing
-    /// @param _conditions The address that can deactivate the hat
+    /// @param _conditions The address that can deactivate the hat [optional]
+    /// @param _topHatImageURI The image uri for this top hat and the fallback for its
+    ///                        children hats [optional]
+    /// @param _firstHatImageURI The image uri for the first hat and the fallback for its
+    ///                        children hats [optional]
     /// @return topHatId The id of the newly created topHat
     /// @return firstHatId The id of the other newly created hat
     function createTopHatAndHat(
         string memory _details, // encode as bytes32 ??
         uint32 _maxSupply,
         address _oracle,
-        address _conditions
+        address _conditions,
+        string memory _topHatImageURI,
+        string memory _firstHatImageURI
     ) public returns (uint256 topHatId, uint256 firstHatId) {
-        topHatId = mintTopHat(msg.sender);
+        topHatId = mintTopHat(msg.sender, _topHatImageURI);
 
         firstHatId = createHat(
             topHatId,
             _details,
             _maxSupply,
             _oracle,
-            _conditions
+            _conditions,
+            _firstHatImageURI
         );
     }
 
@@ -157,13 +174,16 @@ contract Hats is ERC1155 {
     /// @param _admin The id of the Hat that will control who wears the newly created hat
     /// @param _oracle The address that can report on the Hat wearer's status
     /// @param _conditions The address that can deactivate the Hat
+    /// @param _imageURI The image uri for this hat and the fallback for its
+    ///                  children hats [optional]
     /// @return newHatId The id of the newly created Hat
     function createHat(
         uint256 _admin,
         string memory _details, // encode as bytes32 ??
         uint32 _maxSupply,
         address _oracle,
-        address _conditions
+        address _conditions,
+        string memory _imageURI
     ) public returns (uint256 newHatId) {
         // to create a hat, you must be wearing the Hat of its admin
         if (!isWearerOfHat(msg.sender, _admin)) {
@@ -175,7 +195,14 @@ contract Hats is ERC1155 {
 
         newHatId = _buildNextId(_admin);
         // create the new hat
-        _createHat(newHatId, _details, _maxSupply, _oracle, _conditions);
+        _createHat(
+            newHatId,
+            _details,
+            _maxSupply,
+            _oracle,
+            _conditions,
+            _imageURI
+        );
         // increment _admin.lastHatId
         ++_hats[_admin].lastHatId;
     }
@@ -423,14 +450,17 @@ contract Hats is ERC1155 {
     /// @param _details A description of the hat
     /// @param _maxSupply The total instances of the Hat that can be worn at once
     /// @param _oracle The address that can report on the Hat wearer's status
-    /// @param _conditions The address that can deactivate the hat
+    /// @param _conditions The address that can deactivate the hat [optional]
+    /// @param _imageURI The image uri for this top hat and the fallback for its
+    ///                  children hats [optional]
     /// @return hat The contents of the newly created hat
     function _createHat(
         uint256 _id,
         string memory _details, // encode as bytes32 ??
         uint32 _maxSupply,
         address _oracle,
-        address _conditions
+        address _conditions,
+        string memory _imageURI
     ) internal returns (Hat memory hat) {
         hat.details = _details;
 
@@ -439,11 +469,19 @@ contract Hats is ERC1155 {
         hat.oracle = _oracle;
 
         hat.conditions = _conditions;
+        hat.imageURI = _imageURI;
         hat.active = true;
 
         _hats[_id] = hat;
 
-        emit HatCreated(_id, _details, _maxSupply, _oracle, _conditions);
+        emit HatCreated(
+            _id,
+            _details,
+            _maxSupply,
+            _oracle,
+            _conditions,
+            _imageURI
+        );
     }
 
     // TODO write comment
@@ -525,6 +563,7 @@ contract Hats is ERC1155 {
     /// @return supply The number of current wearers of this Hat
     /// @return oracle The Oracle address for this Hat
     /// @return conditions The Conditions address for this Hat
+    /// @return imageURI The image URI used for this Hat
     /// @return lastHatId The most recently created Hat with this Hat as admin; also the count of Hats with this Hat as admin
     /// @return active Whether the Hat is current active, as read from `_isActive`
     function viewHat(uint256 _hatId)
@@ -536,6 +575,7 @@ contract Hats is ERC1155 {
             uint32 supply,
             address oracle,
             address conditions,
+            string memory imageURI,
             uint8 lastHatId,
             bool active
         )
@@ -546,6 +586,7 @@ contract Hats is ERC1155 {
         supply = hatSupply[_hatId];
         oracle = hat.oracle;
         conditions = hat.conditions;
+        imageURI = getImageURIForHat(_hatId);
         lastHatId = hat.lastHatId;
         active = _isActive(hat, _hatId);
     }
@@ -643,6 +684,7 @@ contract Hats is ERC1155 {
     /// @notice Checks the active status of a hat
     /// @dev For internal use instead of `isActive` when passing Hat as param is preferable
     /// @param _hat The Hat struct
+    /// @param _hatId The id of the hat
     /// @return active The active status of the hat
     function _isActive(Hat memory _hat, uint256 _hatId)
         internal
@@ -713,6 +755,47 @@ contract Hats is ERC1155 {
         return _isInGoodStanding(_wearer, hat, _hatId);
     }
 
+    /// @notice Gets the imageURI for a given hat
+    /// @dev If this hat does not have an imageURI set, recursively get the imageURI from
+    ///      its admin
+    /// @param _hatId The hat whose imageURI we're looking for
+    /// @return imageURI The imageURI of this hat or, if empty, its admin
+    function getImageURIForHat(uint256 _hatId)
+        public
+        view
+        returns (string memory)
+    {
+        // check _hatId first to potentially avoid the `getHatLevel` call
+        Hat memory hat = _hats[_hatId];
+
+        string memory imageURI = hat.imageURI; // save 1 SLOAD
+
+        if (bytes(imageURI).length > 0) {
+            // since there's only one hat with this imageURI at this level, by convention
+            // we refer to it with `id = 0`
+            return string.concat(imageURI, "0");
+        }
+
+        // if _hatId doesn't have an imageURI, we fall back to its admin treep
+        uint256 level = getHatLevel(_hatId);
+
+        // already checked at `level`, so we start the loop at `level - 1`
+        for (uint256 i = level; i > 0; --i) {
+            uint256 id = getAdminAtLevel(_hatId, uint8(i - 1));
+            hat = _hats[id];
+            imageURI = hat.imageURI;
+
+            if (bytes(imageURI).length > 0) {
+                // since there are multiple hats with this imageURI at _hatId's level,
+                // we need to use _hatId to disambiguate
+                return string.concat(imageURI, Strings.toString(_hatId));
+            }
+        }
+
+        // if no hat in _hatId's admin tre has an imageURI, we fall back to the global image uri
+        return string.concat(baseImageURI, Strings.toString(_hatId));
+    }
+
     /// @notice Constructs the URI for a Hat, using data from the Hat struct
     /// @param _hatId The id of the Hat
     /// @return uri_ An ERC1155-compatible JSON string
@@ -766,8 +849,8 @@ contract Hats is ERC1155 {
                         Strings.toHexString(_hatId, 32),
                         '", "status": "',
                         status,
-                        //'", "image": "',
-                        // some image URI,
+                        '", "image": "',
+                        getImageURIForHat(_hatId),
                         '", "properties": ',
                         properties,
                         "}"

--- a/src/IHats.sol
+++ b/src/IHats.sol
@@ -85,6 +85,11 @@ interface IHats {
         view
         returns (bool);
 
+    function getImageURIForHat(uint256 _hatId)
+        external
+        view
+        returns (string memory);
+
     function balanceOf(address wearer, uint256 hatId)
         external
         view

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -125,7 +125,24 @@ contract ImageURITest is TestSetup2 {
 
         assertEq(uri, string.concat(_baseImageURI, Strings.toString(ids[4])));
     }
+
+    function testChangeHatImageURI() public {
+        // only a hat's admin can change the hat's imageURI
+    }
+
+    function testNonAdminCannotChangeHatImageURI() public {
+        //
+    }
+
+    function testChangeGlobalBaseImageURI() public {
+        // only the Hats.sol contract owner can change it
+    }
+
+    function testNonOwnerCannotChangeGlobalBaseImageURI() public {
+        //
+    }
 }
+
 
 contract MintHatsTest is TestSetup {
     function setUp() public override {

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -116,7 +116,7 @@ contract ImageURITest is TestSetup2 {
         assertEq(uri, string.concat(_baseImageURI, Strings.toString(topHat)));
     }
 
-    function testEmptyHatBrancheImageURI() public {
+    function testEmptyHatBranchImageURI() public {
         uint256 topHat = hats.mintTopHat(topHatWearer, "");
 
         (uint256[] memory ids, ) = createHatsBranch(5, topHat, topHatWearer);
@@ -130,19 +130,10 @@ contract ImageURITest is TestSetup2 {
         // only a hat's admin can change the hat's imageURI
     }
 
-    function testNonAdminCannotChangeHatImageURI() public {
-        //
-    }
-
-    function testChangeGlobalBaseImageURI() public {
-        // only the Hats.sol contract owner can change it
-    }
-
-    function testNonOwnerCannotChangeGlobalBaseImageURI() public {
-        //
-    }
+    // function testNonOwnerCannotChangeGlobalBaseImageURI() public {
+    //     //
+    // }
 }
-
 
 contract MintHatsTest is TestSetup {
     function setUp() public override {

--- a/test/HatsTestSetup.t.sol
+++ b/test/HatsTestSetup.t.sol
@@ -18,6 +18,11 @@ abstract contract TestVariables {
     uint32 internal _maxSupply;
     address internal _oracle;
     address internal _conditions;
+    string internal _baseImageURI;
+
+    string internal topHatImageURI;
+    string internal secondHatImageURI;
+    string internal thirdHatImageURI;
 
     uint256 internal topHatId;
     uint256 internal secondHatId;
@@ -30,7 +35,8 @@ abstract contract TestVariables {
         string details,
         uint32 maxSupply,
         address oracle,
-        address conditions
+        address conditions,
+        string imageURI
     );
     event HatRenounced(uint256 hatId, address wearer);
     event WearerStatus(
@@ -68,13 +74,16 @@ abstract contract TestSetup is Test, TestVariables {
     function setUp() public virtual {
         setUpVariables();
         // instantiate Hats contract
-        hats = new Hats(name);
+        hats = new Hats(name, _baseImageURI);
 
         // create TopHat
         createTopHat();
     }
 
     function setUpVariables() internal {
+        // set variables: deploy
+        _baseImageURI = "https://www.images.hats.work/";
+
         // set variables: addresses
         topHatWearer = address(1);
         secondWearer = address(2);
@@ -87,19 +96,25 @@ abstract contract TestSetup is Test, TestVariables {
         _oracle = address(555);
         _conditions = address(333);
 
+        topHatImageURI = "http://www.tophat.com/";
+        secondHatImageURI = "http://www.second.com/";
+        thirdHatImageURI = "http://www.third.com/";
+
         name = "Hats Test Contract";
     }
 
     function createTopHat() internal {
         // create TopHat
-        topHatId = hats.mintTopHat(topHatWearer);
+        topHatId = hats.mintTopHat(topHatWearer, "http://www.tophat.com/");
     }
 
     /// @dev assumes a tophat has already been created
-    function createHatsBranch(uint256 _length)
-        internal
-        returns (uint256[] memory ids, address[] memory wearers)
-    {
+    /// @dev doesn't apply any imageURIs
+    function createHatsBranch(
+        uint256 _length,
+        uint256 _topHatId,
+        address _topHatWearer
+    ) internal returns (uint256[] memory ids, address[] memory wearers) {
         uint256 id;
         address wearer;
         uint256 admin;
@@ -109,9 +124,9 @@ abstract contract TestSetup is Test, TestVariables {
         wearers = new address[](_length);
 
         for (uint256 i = 0; i < _length; ++i) {
-            admin = (i == 0) ? topHatId : ids[i - 1];
+            admin = (i == 0) ? _topHatId : ids[i - 1];
 
-            adminWearer = (i == 0) ? topHatWearer : wearers[i - 1];
+            adminWearer = (i == 0) ? _topHatWearer : wearers[i - 1];
 
             // create ith hat from the admin
             vm.prank(adminWearer);
@@ -121,7 +136,8 @@ abstract contract TestSetup is Test, TestVariables {
                 string.concat("hat ", vm.toString(i + 2)),
                 _maxSupply,
                 _oracle,
-                _conditions
+                _conditions,
+                "" // imageURI
             );
             ids[i] = id;
 
@@ -148,7 +164,8 @@ abstract contract TestSetup2 is TestSetup {
             "second hat",
             2, // maxSupply
             _oracle,
-            _conditions
+            _conditions,
+            secondHatImageURI
         );
 
         // mint second hat

--- a/test/HatsTestSetup.t.sol
+++ b/test/HatsTestSetup.t.sol
@@ -99,8 +99,6 @@ abstract contract TestSetup is Test, TestVariables {
         topHatImageURI = "http://www.tophat.com/";
         secondHatImageURI = "http://www.second.com/";
         thirdHatImageURI = "http://www.third.com/";
-
-        name = "Hats Test Contract";
     }
 
     function createTopHat() internal {


### PR DESCRIPTION
- Add imageURI to tophat and hat creation
- Add global baseImageURI
- Add logic for recursive image lookup in hat tree
- See readme for imageURI construction logic with token id

This PR addresses https://github.com/Hats-Protocol/hats-protocol/pull/47