### PR TITLE
Refactor id functions

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -699,7 +699,7 @@ contract Hats is ERC1155, HatsIdUtilities {
         }
 
         string memory domain = Strings.toString(
-            getAdminAtLevel(_hatId, 0) >> (8 * 28)
+            getAdminAtLevel(_hatId, 0) >> (LEVEL_BITS * HAT_TREE_DEPTH)
         );
 
         bytes memory properties = abi.encodePacked(
@@ -710,7 +710,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             '", "admin (id)": "',
             Strings.toString(hatAdmin),
             '", "admin (pretty id)": "',
-            Strings.toHexString(hatAdmin, 32),
+            Strings.toHexString(hatAdmin, TOPHAT_BITS),
             '", "eligibility address": "',
             Strings.toHexString(hat.eligibility),
             '", "toggle address": "',
@@ -730,7 +730,7 @@ contract Hats is ERC1155, HatsIdUtilities {
                         '", "id": "',
                         Strings.toString(_hatId),
                         '", "pretty id": "',
-                        Strings.toHexString(_hatId, 32),
+                        Strings.toHexString(_hatId, TOPHAT_BITS),
                         '", "status": "',
                         status,
                         '", "image": "',

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.13;
 import {ERC1155} from "ERC1155/ERC1155.sol";
 // do we need an interface for Hatter / admin?
 import "forge-std/Test.sol"; //remove after testing
+import "./HatsIdUtilities.sol";
 import "./HatsToggle/IHatsToggle.sol";
 import "./HatsEligibility/IHatsEligibility.sol";
 import "@openzeppelin/contracts/utils/Base64.sol";
@@ -13,7 +14,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 /// @notice Hats are DAO-native revocable roles that are represented as semi-fungable tokens for composability
 /// @dev This contract can manage all Hats for a given chain
 /// @author Hats Protocol
-contract Hats is ERC1155 {
+contract Hats is ERC1155, HatsIdUtilities {
     /*//////////////////////////////////////////////////////////////
                               HATS ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -194,7 +195,7 @@ contract Hats is ERC1155 {
             revert MaxTreeDepthReached();
         }
 
-        newHatId = _buildNextId(_admin);
+        newHatId = getNextId(_admin);
         // create the new hat
         _createHat(
             newHatId,
@@ -208,96 +209,9 @@ contract Hats is ERC1155 {
         ++_hats[_admin].lastChildId;
     }
 
-    function _buildNextId(uint256 _admin) internal returns (uint256) {
+    function getNextId(uint256 _admin) public view returns (uint256) {
         uint8 nextHatId = _hats[_admin].lastChildId + 1;
-
-        if (uint224(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 216);
-        }
-        if (uint216(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 208);
-        }
-        if (uint208(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 200);
-        }
-        if (uint200(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 192);
-        }
-        if (uint192(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 184);
-        }
-        if (uint184(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 176);
-        }
-        if (uint176(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 168);
-        }
-        if (uint168(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 160);
-        }
-        if (uint160(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 152);
-        }
-        if (uint152(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 144);
-        }
-        if (uint144(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 136);
-        }
-        if (uint136(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 128);
-        }
-        if (uint128(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 120);
-        }
-        if (uint120(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 112);
-        }
-        if (uint112(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 104);
-        }
-        if (uint104(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 96);
-        }
-        if (uint96(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 88);
-        }
-        if (uint88(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 80);
-        }
-        if (uint80(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 72);
-        }
-        if (uint72(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 64);
-        }
-        if (uint64(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 56);
-        }
-        if (uint56(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 48);
-        }
-        if (uint48(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 40);
-        }
-
-        if (uint40(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 32);
-        }
-
-        if (uint32(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 24);
-        }
-
-        if (uint24(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 16);
-        }
-
-        if (uint16(_admin) == 0) {
-            return _admin | (uint256(nextHatId) << 8);
-        }
-
-        return _admin | uint256(nextHatId);
+        return buildHatId(_admin, nextHatId);
     }
 
     /// @notice Mints an ERC1155 token of the Hat to a recipient, who then "wears" the hat
@@ -649,49 +563,6 @@ contract Hats is ERC1155 {
         }
 
         return isWearerOfHat(_user, getAdminAtLevel(_hatId, 0));
-    }
-
-    function getHatLevel(uint256 _hatId) public pure returns (uint8 level) {
-        // TODO: invert the order for optimization
-        if (uint8(_hatId) > 0) return 28;
-        if (uint16(_hatId) > 0) return 27;
-        if (uint24(_hatId) > 0) return 26;
-        if (uint32(_hatId) > 0) return 25;
-        if (uint40(_hatId) > 0) return 24;
-        if (uint48(_hatId) > 0) return 23;
-        if (uint56(_hatId) > 0) return 22;
-        if (uint64(_hatId) > 0) return 21;
-        if (uint72(_hatId) > 0) return 20;
-        if (uint80(_hatId) > 0) return 19;
-        if (uint88(_hatId) > 0) return 18;
-        if (uint96(_hatId) > 0) return 17;
-        if (uint104(_hatId) > 0) return 16;
-        if (uint112(_hatId) > 0) return 15;
-        if (uint120(_hatId) > 0) return 14;
-        if (uint128(_hatId) > 0) return 13;
-        if (uint136(_hatId) > 0) return 12;
-        if (uint144(_hatId) > 0) return 11;
-        if (uint152(_hatId) > 0) return 10;
-        if (uint160(_hatId) > 0) return 9;
-        if (uint168(_hatId) > 0) return 8;
-        if (uint176(_hatId) > 0) return 7;
-        if (uint184(_hatId) > 0) return 6;
-        if (uint192(_hatId) > 0) return 5;
-        if (uint200(_hatId) > 0) return 4;
-        if (uint208(_hatId) > 0) return 3;
-        if (uint216(_hatId) > 0) return 2;
-        if (uint224(_hatId) > 0) return 1;
-        return 0;
-    }
-
-    function getAdminAtLevel(uint256 _hatId, uint8 _level)
-        public
-        view
-        returns (uint256)
-    {
-        uint256 mask = type(uint256).max << (8 * (28 - _level));
-
-        return _hatId & mask;
     }
 
     /// @notice Checks the active status of a hat

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -33,7 +33,7 @@ contract Hats is ERC1155, HatsIdUtilities {
     error NotIHatsEligibilityContract();
     error BatchArrayLengthMismatch();
     error SafeTransfersNotNecessary();
-    error MaxTreeDepthReached();
+    error MaxLevelsReached();
 
     /*//////////////////////////////////////////////////////////////
                               HATS DATA MODELS
@@ -63,16 +63,8 @@ contract Hats is ERC1155, HatsIdUtilities {
 
     string public baseImageURI;
 
-    /**
-     * Hat IDs act like addresses. The top level consists of 4 bytes and references all tophats
-     * Each level below consists of 1 byte, which can contain up to 255 types of hats.
-     *
-     * A uint256 contains 4 bytes of space for tophat addresses and 28 bytes of space
-     * for 28 levels of heirarchy of ownership, with the admin at each level having space
-     * for 255 different hats.
-     *
-     */
-    mapping(uint256 => Hat) internal _hats;
+    // see HatsIdUtilities.sol for more info on how Hat Ids work
+    mapping(uint256 => Hat) internal _hats; // key: hatId => value: Hat struct
 
     mapping(uint256 => uint32) public hatSupply; // key: hatId => value: supply
 
@@ -192,7 +184,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             revert NotAdmin(msg.sender, _admin);
         }
         if (uint8(_admin) > 0) {
-            revert MaxTreeDepthReached();
+            revert MaxLevelsReached();
         }
 
         newHatId = getNextId(_admin);
@@ -208,7 +200,6 @@ contract Hats is ERC1155, HatsIdUtilities {
         // increment _admin.lastHatId
         ++_hats[_admin].lastHatId;
     }
-
 
     function getNextId(uint256 _admin) public view returns (uint256) {
         uint8 nextHatId = _hats[_admin].lastHatId + 1;
@@ -711,7 +702,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             '", "admin (id)": "',
             Strings.toString(hatAdmin),
             '", "admin (pretty id)": "',
-            Strings.toHexString(hatAdmin, TOPHAT_BITS),
+            Strings.toHexString(hatAdmin, 32),
             '", "eligibility address": "',
             Strings.toHexString(hat.eligibility),
             '", "toggle address": "',
@@ -731,7 +722,7 @@ contract Hats is ERC1155, HatsIdUtilities {
                         '", "id": "',
                         Strings.toString(_hatId),
                         '", "pretty id": "',
-                        Strings.toHexString(_hatId, TOPHAT_BITS),
+                        Strings.toHexString(_hatId, 32),
                         '", "status": "',
                         status,
                         '", "image": "',

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -509,14 +509,6 @@ contract Hats is ERC1155, HatsIdUtilities {
         active = _isActive(hat, _hatId);
     }
 
-    /// @notice Chcecks whether a Hat is a topHat
-    /// @dev For use when passing a Hat object is not appropriate
-    /// @param _hatId The Hat in question
-    /// @return bool Whether the Hat is a topHat
-    function isTopHat(uint256 _hatId) public pure returns (bool) {
-        return _hatId > 0 && uint224(_hatId) == 0;
-    }
-
     /// @notice Checks whether a given address wears a given Hat
     /// @dev Convenience function that wraps `balanceOf`
     /// @param _user The address in question
@@ -690,9 +682,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             hatAdmin = getAdminAtLevel(_hatId, getHatLevel(_hatId) - 1);
         }
 
-        string memory domain = Strings.toString(
-            getAdminAtLevel(_hatId, 0) >> (LEVEL_BITS * HAT_TREE_DEPTH)
-        );
+        string memory domain = Strings.toString(getTophatDomain(_hatId));
 
         bytes memory properties = abi.encodePacked(
             '{"current supply": "',

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -2,7 +2,8 @@
 pragma solidity >=0.8.13;
 
 /// @title Hats Id Utilities
-/// @dev Functions for working with Hat Ids from Hats Protocol
+/// @dev Functions for working with Hat Ids from Hats Protocol. Factored out of Hats.sol
+/// for easier use by other contracts.
 /// @author Hats Protocol
 contract HatsIdUtilities {
     /**

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -66,6 +66,13 @@ contract HatsIdUtilities {
         }
     }
 
+    /// @notice Checks whether a hat is a topHat
+    /// @dev For use when passing a Hat object is not appropriate
+    /// @param _hatId The hat in question
+    /// @return bool Whether the hat is a topHat
+    function isTopHat(uint256 _hatId) public pure returns (bool) {
+        return _hatId > 0 && uint224(_hatId) == 0;
+    }
 
     /// @notice Gets the hat id of the admin at a given level of a given hat
     /// @param _hatId the id of the hat in question
@@ -82,22 +89,13 @@ contract HatsIdUtilities {
         return _hatId & mask;
     }
 
-    function buildHatId(uint256 _admin, uint8 _newChild)
-        public
-        pure
-        returns (uint256)
-    {
-        uint256 mask;
-        for (uint256 i = 0; i < HAT_TREE_DEPTH; ++i) {
-            mask = uint256(
-                type(uint256).max >> (TOPHAT_BITS + (LEVEL_BITS * i))
-            );
-            if (_admin & mask == 0) {
+    /// @notice Gets the tophat domain of a given hat
+    /// @dev A domain is the identifier for a given hat tree, stored in the first 4 bytes of a hat's id
+    /// @param _hatId the id of the hat in question
+    /// @return uint256 The domain
+    function getTophatDomain(uint256 _hatId) public pure returns (uint256) {
         return
-                    _admin |
-                    (uint256(_newChild) <<
-                        (LEVEL_BITS * (HAT_TREE_DEPTH - 1 - i)));
-            }
-        }
+            getAdminAtLevel(_hatId, 0) >>
+            (LOWER_LEVEL_ADDRESS_SPACE * MAX_LEVELS);
     }
 }

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -2,6 +2,10 @@
 pragma solidity >=0.8.13;
 
 contract HatsIdUtilities {
+    uint256 internal constant TOPHAT_BITS = 32;
+    uint256 internal constant LEVEL_BITS = 8;
+    uint256 internal constant HAT_TREE_DEPTH = 28;
+
     function getHatLevel(uint256 _hatId) public pure returns (uint8 level) {
         uint256 mask;
         uint256 i;

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: CC0
+pragma solidity >=0.8.13;
+
+contract HatsIdUtilities {
+    function getHatLevel(uint256 _hatId) public pure returns (uint8 level) {
+        uint256 mask;
+        uint256 i;
+        for (i = 0; i < HAT_TREE_DEPTH; ++i) {
+            mask = uint256(
+                type(uint256).max >> (TOPHAT_BITS + (LEVEL_BITS * i))
+            );
+
+            if (_hatId & mask == 0) return uint8(i);
+        }
+    }
+
+    function getAdminAtLevel(uint256 _hatId, uint8 _level)
+        public
+        pure
+        returns (uint256)
+    {
+        uint256 mask = type(uint256).max <<
+            (LEVEL_BITS * (HAT_TREE_DEPTH - _level));
+
+        return _hatId & mask;
+    }
+
+    function buildHatId(uint256 _admin, uint8 _newChild)
+        public
+        pure
+        returns (uint256)
+    {
+        uint256 mask;
+        for (uint256 i = 0; i < HAT_TREE_DEPTH; ++i) {
+            mask = uint256(
+                type(uint256).max >> (TOPHAT_BITS + (LEVEL_BITS * i))
+            );
+            if (_admin & mask == 0) {
+                return
+                    _admin |
+                    (uint256(_newChild) <<
+                        (LEVEL_BITS * (HAT_TREE_DEPTH - 1 - i)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- simplify and shorten hat id functions
- refactor them into a new inherited contract
- use ide component constants for readability