### PR TITLE
Update eligibility and revoke logic to use isEligible instead of isInGoodStanding

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -301,7 +301,7 @@ contract Hats is ERC1155, HatsIdUtilities {
     function setHatWearerStatus(
         uint256 _hatId,
         address _wearer,
-        bool _revoke,
+        bool _eligible,
         bool _wearerStanding
     ) external returns (bool) {
         Hat memory hat = _hats[_hatId];
@@ -310,7 +310,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             revert NotHatEligibility();
         }
 
-        _processHatWearerStatus(_hatId, _wearer, _revoke, _wearerStanding);
+        _processHatWearerStatus(_hatId, _wearer, _eligible, _wearerStanding);
 
         return true;
     }

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -295,14 +295,15 @@ contract Hats is ERC1155, HatsIdUtilities {
     /// @dev Burns the wearer's hat, if revoked
     /// @param _hatId The id of the hat
     /// @param _wearer The address of the hat wearer whose status is being reported
-    /// @param _revoke True if the wearer should no longer wear the hat
-    /// @param _wearerStanding False if the wearer is no longer in good standing (and potentially should be penalized)
+    /// @param _eligible Whether the wearer is eligible for the hat (will be revoked if
+    /// false)
+    /// @param _standing False if the wearer is no longer in good standing (and potentially should be penalized)
     /// @return bool Whether the report succeeded
     function setHatWearerStatus(
         uint256 _hatId,
         address _wearer,
         bool _eligible,
-        bool _wearerStanding
+        bool _standing
     ) external returns (bool) {
         Hat memory hat = _hats[_hatId];
 
@@ -310,7 +311,7 @@ contract Hats is ERC1155, HatsIdUtilities {
             revert NotHatEligibility();
         }
 
-        _processHatWearerStatus(_hatId, _wearer, _eligible, _wearerStanding);
+        _processHatWearerStatus(_hatId, _wearer, _eligible, _standing);
 
         return true;
     }

--- a/src/HatsEligibility/IHatsEligibility.sol
+++ b/src/HatsEligibility/IHatsEligibility.sol
@@ -2,8 +2,14 @@
 pragma solidity >=0.8.13;
 
 interface IHatsEligibility {
+    /// @notice Returns the status of a wearer for a given hat
+    /// @dev If standing is false, eligibility MUST also be false
+    /// @param _wearer The address of the current or prospective Hat wearer
+    /// @param _hatId The id of the hat in question
+    /// @return eligibility Whether the _wearer is eligible to wear the hat
+    /// @return standing Whether the _wearer is in goog standing
     function getWearerStatus(address _wearer, uint256 _hatId)
         external
         view
-        returns (bool, bool);
+        returns (bool eligible, bool standing);
 }

--- a/src/HatsEligibility/IHatsEligibility.sol
+++ b/src/HatsEligibility/IHatsEligibility.sol
@@ -6,7 +6,7 @@ interface IHatsEligibility {
     /// @dev If standing is false, eligibility MUST also be false
     /// @param _wearer The address of the current or prospective Hat wearer
     /// @param _hatId The id of the hat in question
-    /// @return eligibility Whether the _wearer is eligible to wear the hat
+    /// @return eligible Whether the _wearer is eligible to wear the hat
     /// @return standing Whether the _wearer is in goog standing
     function getWearerStatus(address _wearer, uint256 _hatId)
         external

--- a/src/HatsEligibility/SampleHatsEligibility.sol
+++ b/src/HatsEligibility/SampleHatsEligibility.sol
@@ -10,7 +10,7 @@ abstract contract OwnableHatsEligibility is IHats, IHatsEligibility, Auth {
     event HatStandingSet(
         address _wearer,
         uint256 _hatId,
-        bool _revoke,
+        bool _eligible,
         bool _standing
     );
 
@@ -33,21 +33,21 @@ abstract contract OwnableHatsEligibility is IHats, IHatsEligibility, Auth {
     function setWearerStatus(
         address _wearer,
         uint256 _hatId,
-        bool _revoke,
+        bool _eligible,
         bool _standing
     ) public virtual requiresAuth {
         standings[_wearer][_hatId] = _standing;
-        _updateHatWearerStatus(_wearer, _hatId, _revoke, _standing);
+        _updateHatWearerStatus(_wearer, _hatId, _eligible, _standing);
 
-        emit HatStandingSet(_wearer, _hatId, _revoke, _standing);
+        emit HatStandingSet(_wearer, _hatId, _eligible, _standing);
     }
 
     function _updateHatWearerStatus(
         address _wearer,
         uint256 _hatId,
-        bool _revoke,
+        bool _eligible,
         bool _standing
     ) internal virtual {
-        HATS.setHatWearerStatus(_hatId, _wearer, _revoke, _standing);
+        HATS.setHatWearerStatus(_hatId, _wearer, _eligible, _standing);
     }
 }

--- a/src/IHats.sol
+++ b/src/IHats.sol
@@ -6,8 +6,8 @@ interface IHats {
         uint256 admin,
         string memory details, // encode as bytes32 ??
         uint32 maxSupply,
-        address oracle,
-        address conditions
+        address eligibility,
+        address toggle
     ) external returns (uint256 hatId);
 
     function mintHat(uint256 _hatId, address _wearer) external returns (bool);
@@ -24,13 +24,13 @@ interface IHats {
 
     function getHatWearerStatus(uint256 hatId, address wearer)
         external
-        returns (bool);
+        returns (bool, bool);
 
     function setHatWearerStatus(
         uint256 hatId,
         address wearer,
-        bool revoke,
-        bool wearerStanding
+        bool eligible,
+        bool standing
     ) external returns (bool);
 
     function renounceHat(uint256 _hatId) external;
@@ -81,6 +81,11 @@ interface IHats {
     function isActive(uint256 _hatId) external view returns (bool);
 
     function isInGoodStanding(address _wearer, uint256 _hatId)
+        external
+        view
+        returns (bool);
+
+    function isEligible(address _wearer, uint256 _hatId)
         external
         view
         returns (bool);

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -633,7 +633,7 @@ contract EligibilitySetHatsTests is TestSetup2 {
 
         // set eligibility = true in Eligibility Module
 
-        // mock calls to eligibility contract to return (eligible = false, standing = true)
+        // mock calls to eligibility contract to return (eligible = true, standing = true)
         vm.mockCall(
             address(_eligibility),
             abi.encodeWithSignature(

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -547,31 +547,31 @@ contract TransferHatTests is TestSetup2 {
 }
 
 contract EligibilitySetHatsTests is TestSetup2 {
-    function testDoNotRevokeHatFromWearerInGoodStanding() public {
+    function testDoNotRevokeHatFromEligibleWearerInGoodStanding() public {
         // confirm second hat is worn by second Wearer
         assertTrue(hats.isWearerOfHat(secondWearer, secondHatId));
 
         // expectEmit WearerStatus - should be wearing, in good standing
         vm.expectEmit(false, false, false, true);
-        emit WearerStatus(secondHatId, secondWearer, false, true);
+        emit WearerStatus(secondHatId, secondWearer, true, true);
 
         // 5-6. do not revoke hat
         vm.prank(address(_eligibility));
-        hats.setHatWearerStatus(secondHatId, secondWearer, false, true);
+        hats.setHatWearerStatus(secondHatId, secondWearer, true, true);
         assertTrue(hats.isWearerOfHat(secondWearer, secondHatId));
         assertTrue(hats.isInGoodStanding(secondWearer, secondHatId));
     }
 
-    function testRevokeHatFromWearerInGoodStanding() public {
+    function testRevokeHatFromIneligibleWearerInGoodStanding() public {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
         // expectEmit WearerStatus - should not be wearing, in good standing
         vm.expectEmit(false, false, false, true);
-        emit WearerStatus(secondHatId, secondWearer, true, true);
+        emit WearerStatus(secondHatId, secondWearer, false, true);
 
         // 5-8a. revoke hat
         vm.prank(address(_eligibility));
-        hats.setHatWearerStatus(secondHatId, secondWearer, true, true);
+        hats.setHatWearerStatus(secondHatId, secondWearer, false, true);
         assertFalse(hats.isWearerOfHat(secondWearer, secondHatId));
         assertTrue(hats.isInGoodStanding(secondWearer, secondHatId));
 
@@ -579,7 +579,19 @@ contract EligibilitySetHatsTests is TestSetup2 {
         assertEq(hats.hatSupply(secondHatId), --hatSupply);
     }
 
-    function testRevokeHatFromWearerInBadStanding() public {
+    function testRevokeHatFromIneligibleWearerInBadStanding() public {
+        // expectEmit WearerStatus - should not be wearing, in bad standing
+        vm.expectEmit(false, false, false, true);
+        emit WearerStatus(secondHatId, secondWearer, false, false);
+
+        // 5-8b. revoke hat with bad standing
+        vm.prank(address(_eligibility));
+        hats.setHatWearerStatus(secondHatId, secondWearer, false, false);
+        assertFalse(hats.isWearerOfHat(secondWearer, secondHatId));
+        assertFalse(hats.isInGoodStanding(secondWearer, secondHatId));
+    }
+
+    function testRevokeHatFromEligibleWearerInBadStanding() public {
         // expectEmit WearerStatus - should not be wearing, in bad standing
         vm.expectEmit(false, false, false, true);
         emit WearerStatus(secondHatId, secondWearer, true, false);
@@ -613,11 +625,24 @@ contract EligibilitySetHatsTests is TestSetup2 {
 
         // revoke hat
         vm.prank(address(_eligibility));
-        hats.setHatWearerStatus(secondHatId, secondWearer, true, true);
+        hats.setHatWearerStatus(secondHatId, secondWearer, false, true);
 
         // 5-4. remint hat
         vm.prank(address(topHatWearer));
         hats.mintHat(secondHatId, secondWearer);
+
+        // set eligibility = true in Eligibility Module
+
+        // mock calls to eligibility contract to return (eligible = false, standing = true)
+        vm.mockCall(
+            address(_eligibility),
+            abi.encodeWithSignature(
+                "getWearerStatus(address,uint256)",
+                secondWearer,
+                secondHatId
+            ),
+            abi.encode(true, true)
+        );
 
         // assert balance = 1
         assertEq(hats.balanceOf(secondWearer, secondHatId), 1);
@@ -643,9 +668,7 @@ contract EligibilityGetHatsTests is TestSetup2 {
         hats.checkHatWearerStatus(secondHatId, secondWearer);
     }
 
-    function testCheckEligibilityAndDoNotRevokeHatFromWearerInGoodStanding()
-        public
-    {
+    function testCheckEligibilityAndDoNotRevokeHatFromEligibleWearer() public {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
         // confirm second hat is worn by second Wearer
@@ -653,9 +676,9 @@ contract EligibilityGetHatsTests is TestSetup2 {
 
         // expectEmit WearerStatus - should be wearing, in good standing
         vm.expectEmit(false, false, false, true);
-        emit WearerStatus(secondHatId, secondWearer, false, true);
+        emit WearerStatus(secondHatId, secondWearer, true, true);
 
-        // mock calls to eligibility contract to return (false, true)
+        // mock calls to eligibility contract to return (eligible = true, standing = true)
         vm.mockCall(
             address(_eligibility),
             abi.encodeWithSignature(
@@ -663,7 +686,7 @@ contract EligibilityGetHatsTests is TestSetup2 {
                 secondWearer,
                 secondHatId
             ),
-            abi.encode(false, true)
+            abi.encode(true, true)
         );
 
         // 5-1. call checkHatWearerStatus - no revocation
@@ -675,14 +698,16 @@ contract EligibilityGetHatsTests is TestSetup2 {
         assertEq(hats.hatSupply(secondHatId), hatSupply);
     }
 
-    function testCheckEligibilityToRevokeHatFromWearerInGoodStanding() public {
+    function testCheckEligibilityToRevokeHatFromIneligibleWearerInGoodStanding()
+        public
+    {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
         // expectEmit WearerStatus - should not be wearing, in good standing
         vm.expectEmit(false, false, false, true);
-        emit WearerStatus(secondHatId, secondWearer, true, true);
+        emit WearerStatus(secondHatId, secondWearer, false, true);
 
-        // mock calls to eligibility contract to return (false, true)
+        // mock calls to eligibility contract to return (eligible = false, standing = true)
         vm.mockCall(
             address(_eligibility),
             abi.encodeWithSignature(
@@ -690,7 +715,7 @@ contract EligibilityGetHatsTests is TestSetup2 {
                 secondWearer,
                 secondHatId
             ),
-            abi.encode(true, true)
+            abi.encode(false, true)
         );
 
         // 5-3a. call checkHatWearerStatus to revoke
@@ -702,14 +727,45 @@ contract EligibilityGetHatsTests is TestSetup2 {
         assertEq(hats.hatSupply(secondHatId), --hatSupply);
     }
 
-    function testCheckEligibilityToRevokeHatFromWearerInBadStanding() public {
+    function testCheckEligibilityToRevokeHatFromIneligibleWearerInBadStanding()
+        public
+    {
+        uint32 hatSupply = hats.hatSupply(secondHatId);
+
+        // expectEmit WearerStatus - should not be wearing, in bad standing
+        vm.expectEmit(false, false, false, true);
+        emit WearerStatus(secondHatId, secondWearer, false, false);
+
+        // mock calls to eligibility contract to return (eligible = false, standing = false)
+        vm.mockCall(
+            address(_eligibility),
+            abi.encodeWithSignature(
+                "getWearerStatus(address,uint256)",
+                secondWearer,
+                secondHatId
+            ),
+            abi.encode(false, false)
+        );
+
+        // 5-3b. call checkHatWearerStatus to revoke
+        hats.checkHatWearerStatus(secondHatId, secondWearer);
+        assertFalse(hats.isWearerOfHat(secondWearer, secondHatId));
+        assertFalse(hats.isInGoodStanding(secondWearer, secondHatId));
+
+        // assert hatSupply is decremented
+        assertEq(hats.hatSupply(secondHatId), --hatSupply);
+    }
+
+    function testCheckEligibilityToRevokeHatFromEligibleWearerInBadStanding()
+        public
+    {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
         // expectEmit WearerStatus - should not be wearing, in bad standing
         vm.expectEmit(false, false, false, true);
         emit WearerStatus(secondHatId, secondWearer, true, false);
 
-        // mock calls to eligibility contract to return (false, true)
+        // mock calls to eligibility contract to return (eligible = true, standing = false)
         vm.mockCall(
             address(_eligibility),
             abi.encodeWithSignature(


### PR DESCRIPTION
Previously, revocation logic was keyed only off of wearer standing, which reduced flexibility for how eligibility modules could inform a wearer's status. Essentially, the only wearer status that really mattered was the standing.

This PR addresses this by introducing  several related changes:

1. Change `getWearerStatus` in the eligibility module interface to return bools `eligible` and `standing`.

2. Add a new view function `isEligble`  that returns the `eligible` result from (1), or -- in the case of a humanistic eligibility module -- returns the standing from `badStandings` in Hats.sol storage.

3. Ensures that `eligible` is always false whenever `standing` is false, ie you can't be eligible for a hat if you are deemed in bad standing.

4. Updates `setHatWearerStatus` and `checkHatWearerStatus` to use the new above logic.

Together, the result is that DAOs can now...

- revoke hats from wearers even when they are in good standing

- revoke hats from wearers even when only the standing changes to bad (false), ie even when the eligibility module still returns `eligible = true`

- more generally, manipulate wearer eligibility and standing separately for greater flexibility