### PR TITLE
Fix uri bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 broadcast/*/31337
 broadcast/*/*/dry-run
 .env
+uri.json

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,7 @@ optimism = "${OPTIMISM_RPC}"
 goerli = "${GOERLI_RPC}"
 gnosis = "${GC_RPC}"
 polygon = "${POLYGON_RPC}"
+local = "http://localhost:8545"
 
 [etherscan]
 arbitrum = {key = "${ARBISCAN_KEY}", url = "https://api.arbiscan.io/api"}

--- a/script/Hats.s.sol
+++ b/script/Hats.s.sol
@@ -6,11 +6,11 @@ import "../src/Hats.sol";
 
 contract DeployHats is Script {
     string public imageURI = "";
-    // string public name = "Hats Protocol - Beta 4"; // increment this each test deployment
-    string public name = "Hats Protocol - uri test 5";
+    string public name = "Hats Protocol - Beta 4"; // increment this each beta deployment
 
     function run() external {
         uint256 privKey = vm.envUint("PRIVATE_KEY");
+
         address deployer = vm.rememberKey(privKey);
         vm.startBroadcast(deployer);
 
@@ -19,6 +19,43 @@ contract DeployHats is Script {
         vm.stopBroadcast();
     }
 
-    // forge script script/Hats.s.sol -f goerli
-    // forge script script/Hats.s.sol -f polygon --broadcast --verify
+    // forge script script/Hats.s.sol:DeployHats -f goerli
+    // forge script script/Hats.s.sol:DeployHats -f polygon --broadcast --verify
+
+    // forge script script/Hats.s.sol:DeployHats --rpc-url http://localhost:8545 --broadcast
+
+    // forge verify-contract --chain-id 5 --num-of-optimizations 1000000 --watch --constructor-args $(cast abi-encode "constructor(string,string)" "Hats Protocol - beta XYZ" "") --compiler-version v0.8.16 <contract address> src/Hats.sol:Hats $ETHERSCAN_API
+}
+
+contract DeployHatsAndMintTopHat is Script {
+    string public imageURI = "";
+    string public name = "Hats Protocol - Test XYZ";
+
+    function run() external {
+        uint256 privKey = vm.envUint("PRIVATE_KEY");
+        // uint256 privKey = uint256(
+        //     0x0
+        // );
+
+        address deployer = vm.rememberKey(privKey);
+        vm.startBroadcast(deployer);
+
+        Hats hats = new Hats(name, imageURI);
+
+        string memory image = "";
+
+        uint256 tophat = hats.mintTopHat(deployer, image);
+
+        console2.log("hats: ", address(hats));
+        console2.log("tophat: ", tophat);
+
+        vm.stopBroadcast();
+    }
+
+    // forge script script/Hats.s.sol:DeployHatsAndMintTopHat -f goerli
+    // forge script script/Hats.s.sol:DeployHatsAndMintTopHat -f polygon --broadcast --verify
+
+    // forge script script/Hats.s.sol:DeployHatsAndMintTopHat --rpc-url http://localhost:8545 --broadcast
+
+    // forge verify-contract --chain-id 5 --num-of-optimizations 1000000 --watch --constructor-args $(cast abi-encode "constructor(string,string)" "Hats Protocol - uri test 7" "") --compiler-version v0.8.16 "0x9b50ab91b3ffbcdd5d5ed49ed70bf299434c955c" src/Hats.sol:Hats $ETHERSCAN_API
 }

--- a/script/Hats.s.sol
+++ b/script/Hats.s.sol
@@ -5,8 +5,9 @@ import "forge-std/Script.sol";
 import "../src/Hats.sol";
 
 contract DeployHats is Script {
-    string public imageURI = "hats-beta4:";
-    string public name = "Hats Protocol - Beta 4"; // increment this each test deployment
+    string public imageURI = "";
+    // string public name = "Hats Protocol - Beta 4"; // increment this each test deployment
+    string public name = "Hats Protocol - uri test 5";
 
     function run() external {
         uint256 privKey = vm.envUint("PRIVATE_KEY");
@@ -18,6 +19,6 @@ contract DeployHats is Script {
         vm.stopBroadcast();
     }
 
-    // forge script script/Hats.s.sol -f polygon
+    // forge script script/Hats.s.sol -f goerli
     // forge script script/Hats.s.sol -f polygon --broadcast --verify
 }

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -727,30 +727,48 @@ contract Hats is ERC1155, HatsIdUtilities {
 
         string memory imageURI = hat.imageURI; // save 1 SLOAD
 
+        // if _hatId has an imageURI, we return it
         if (bytes(imageURI).length > 0) {
+            return imageURI;
+
+            /// TODO bring back the following in a way that actually works
             // since there's only one hat with this imageURI at this level, by convention
             // we refer to it with `id = 0`
-            return string.concat(imageURI, "0");
+            // return string.concat(imageURI, "0");
         }
 
-        // if _hatId doesn't have an imageURI, we fall back to its admin tree
+        // otherwise, we check its branch of admins
         uint256 level = getHatLevel(_hatId);
 
-        // already checked at `level`, so we start the loop at `level - 1`
-        for (uint256 i = level; i > 0; --i) {
-            uint256 id = getAdminAtLevel(_hatId, uint8(i - 1));
+        // but first we check if _hatId is a tophat, in which case we fall back to the global image uri
+        if (level == 0) return baseImageURI;
+
+        // otherwise, we check each of its admins for a valid imageURI
+        uint256 id;
+        console2.log("level", level);
+
+        // already checked at `level` above, so we start the loop at `level - 1`
+        for (uint256 i = level - 1; i > 0; --i) {
+            console2.log("i", i);
+            id = getAdminAtLevel(_hatId, uint8(i));
             hat = _hats[id];
             imageURI = hat.imageURI;
 
             if (bytes(imageURI).length > 0) {
+                return imageURI;
+
+                /// TODO bring back the following in a way that actually works
                 // since there are multiple hats with this imageURI at _hatId's level,
                 // we need to use _hatId to disambiguate
-                return string.concat(imageURI, Strings.toString(_hatId));
+                // return string.concat(imageURI, Strings.toString(_hatId));
             }
         }
 
-        // if no hat in _hatId's admin tre has an imageURI, we fall back to the global image uri
-        return string.concat(baseImageURI, Strings.toString(_hatId));
+        // if none of _hatId's admins has an imageURI of its own, we again fall back to the global image uri
+        return baseImageURI;
+
+        /// TODO bring back the following in a way that actually works
+        // return string.concat(baseImageURI, Strings.toString(_hatId));
     }
 
     /// @notice Constructs the URI for a Hat, using data from the Hat struct

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -828,7 +828,7 @@ contract Hats is ERC1155, HatsIdUtilities {
                     '", "image": "',
                     getImageURIForHat(_hatId),
                     '",',
-                    '"attributes":',
+                    '"properties": ',
                     "{",
                     idProperties,
                     otherProperties,

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -771,10 +771,21 @@ contract Hats is ERC1155, HatsIdUtilities {
             hatAdmin = getAdminAtLevel(_hatId, getHatLevel(_hatId) - 1);
         }
 
-        string memory domain = Strings.toString(getTophatDomain(_hatId));
+        // split into two objects to avoid stack too deep error
+        string memory idProperties = string.concat(
+            '"domain": "',
+            Strings.toString(getTophatDomain(_hatId)),
+            '", "id": "',
+            Strings.toString(_hatId),
+            '", "pretty id": "',
+            "{id}",
+            '",'
+        );
 
-        bytes memory properties = abi.encodePacked(
-            '{"current supply": "',
+        string memory otherProperties = string.concat(
+            '"status": "',
+            (_isActive(hat, _hatId) ? "active" : "inactive"),
+            '", "current supply": "',
             Strings.toString(hatSupply[_hatId]),
             '", "supply cap": "',
             Strings.toString(hat.maxSupply),
@@ -782,34 +793,29 @@ contract Hats is ERC1155, HatsIdUtilities {
             Strings.toString(hatAdmin),
             '", "admin (pretty id)": "',
             Strings.toHexString(hatAdmin, 32),
-            '", "eligibility address": "',
+            '", "eligibility module": "',
             Strings.toHexString(hat.eligibility),
-            '", "toggle address": "',
+            '", "toggle module": "',
             Strings.toHexString(hat.toggle),
-            '"}'
+            '"'
         );
-        string memory status = (_isActive(hat, _hatId) ? "active" : "inactive");
 
         string memory json = Base64.encode(
             bytes(
-                string(
-                    abi.encodePacked(
-                        '{"name & description": "',
-                        hat.details, // alternatively, could point to a URI for offchain flexibility
-                        '", "domain": "',
-                        domain,
-                        '", "id": "',
-                        Strings.toString(_hatId),
-                        '", "pretty id": "',
-                        Strings.toHexString(_hatId, 32),
-                        '", "status": "',
-                        status,
-                        '", "image": "',
-                        getImageURIForHat(_hatId),
-                        '", "properties": ',
-                        properties,
-                        "}"
-                    )
+                string.concat(
+                    '{"name": "',
+                    "Hats Protocol Hat",
+                    '", "description": "',
+                    "this is a test of Hats Protocol nfts", // alternatively, could point to a URI for offchain flexibility
+                    '", "image": "',
+                    getImageURIForHat(_hatId),
+                    '",',
+                    '"attributes":',
+                    "{",
+                    idProperties,
+                    otherProperties,
+                    "}",
+                    "}"
                 )
             )
         );

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -295,13 +295,15 @@ contract ImageURITest is TestSetup2 {
     function testTopHatImageURI() public {
         string memory uri = hats.getImageURIForHat(topHatId);
 
-        assertEq(string.concat(topHatImageURI, "0"), uri);
+        // assertEq(string.concat(topHatImageURI, "0"), uri);
+        assertEq(uri, topHatImageURI);
     }
 
     function testHatImageURI() public {
         string memory uri = hats.getImageURIForHat(secondHatId);
 
-        assertEq(string.concat(secondHatImageURI, "0"), uri);
+        // assertEq(string.concat(secondHatImageURI, "0"), uri);
+        assertEq(uri, secondHatImageURI);
     }
 
     function testEmptyHatImageURI() public {
@@ -318,10 +320,12 @@ contract ImageURITest is TestSetup2 {
 
         string memory uri3 = hats.getImageURIForHat(thirdHatId);
 
-        assertEq(
-            uri3,
-            string.concat(secondHatImageURI, Strings.toString(thirdHatId))
-        );
+        // assertEq(
+        //     uri3,
+        //     string.concat(secondHatImageURI, Strings.toString(thirdHatId))
+        // );
+
+        assertEq(uri3, secondHatImageURI);
     }
 
     function testEmptyTopHatImageURI() public {
@@ -329,7 +333,8 @@ contract ImageURITest is TestSetup2 {
 
         string memory uri = hats.getImageURIForHat(topHat);
 
-        assertEq(uri, string.concat(_baseImageURI, Strings.toString(topHat)));
+        // assertEq(uri, string.concat(_baseImageURI, Strings.toString(topHat)));
+        assertEq(uri, _baseImageURI);
     }
 
     function testEmptyHatBranchImageURI() public {
@@ -339,7 +344,8 @@ contract ImageURITest is TestSetup2 {
 
         string memory uri = hats.getImageURIForHat(ids[4]);
 
-        assertEq(uri, string.concat(_baseImageURI, Strings.toString(ids[4])));
+        // assertEq(uri, string.concat(_baseImageURI, Strings.toString(ids[4])));
+        assertEq(uri, _baseImageURI);
     }
 
     // function testChangeGlobalBaseImageURI() public {
@@ -668,7 +674,8 @@ contract ViewHatTests is TestSetup2 {
         assertEq(retsupply, 1);
         assertEq(reteligibility, address(555));
         assertEq(rettoggle, address(333));
-        assertEq(retimageURI, string.concat(secondHatImageURI, "0"));
+        // assertEq(retimageURI, string.concat(secondHatImageURI, "0"));
+        assertEq(retimageURI, secondHatImageURI);
         assertEq(retlastHatId, 0);
         assertEq(retactive, true);
     }


### PR DESCRIPTION
The upshot is that now hat metadata and image is now displaying properly on platforms like opensea. [Example here](https://testnets.opensea.io/assets/goerli/0x2250e279d2452501640f4d91e2e89a5e08dbd00f/26959946667150639794667015087019630673637144422540572481103610249216).

- Fix json formatting issues
- Simplify `getImageURIForHat()` to return the imageURI itself rather than appending the hat id (would like to bring that functionality back in the future if we can figure out a clean way of doing it) 