### PR TITLE
Implement initial semantic coverage for hat id utils

### DIFF
--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -39,6 +39,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
         returns (uint256 id)
     {
         uint256 mask;
+        // TODO: remove this loop
         for (uint256 i = 0; i < MAX_LEVELS; ++i) {
             mask = uint256(
                 type(uint256).max >>
@@ -60,6 +61,8 @@ contract HatsIdUtilities is IHatsIdUtilities {
     function getHatLevel(uint256 _hatId) public pure returns (uint8) {
         uint256 mask;
         uint256 i;
+        // TODO: get rid of this for loop and possibly use the YUL switch/case
+        // syntax. Otherwise, return to the original syntax
         for (i = 0; i < MAX_LEVELS; ++i) {
             mask = uint256(
                 type(uint256).max >>

--- a/test/HatsIdUtils.t.sol
+++ b/test/HatsIdUtils.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../src/HatsIdUtilities.sol";
+
+contract HatIdUtilTests is Test {
+    HatsIdUtilities utils;
+
+    function setUp() public {
+        utils = new HatsIdUtilities();
+    }
+
+    function testgetHatLevel() public {
+        for (uint256 i = 1; 2 ** i < type(uint224).max; i += 8) {
+            // each byte corresponds with a level
+            assertEq(utils.getHatLevel(2 ** i), 28 - (i / 8));
+            if (i > 1) {
+                assertEq(utils.getHatLevel(2 ** i + 256), 27);
+            }
+        }
+    }
+
+    function testBuildHatId() public {
+        // start with a top hat
+        uint256 admin = 1 << 224;
+        uint256 next;
+        for (uint8 i = 1; i < 29; i++) {
+            next = utils.buildHatId(admin, 1);
+            assertEq(utils.getHatLevel(next), i);
+            assertEq(utils.getAdminAtLevel(next, i - 1), admin);
+            admin = next;
+        }
+    }
+
+    function testTopHatDomain() public {
+        uint256 admin = 1 << 224;
+        assertEq(utils.isTopHat(admin), true);
+        assertEq(utils.isTopHat(admin + 1 << 216), false);
+        assertEq(utils.isTopHat(admin + 1), false);
+        assertEq(utils.isTopHat(admin - 1), false);
+
+        assertEq(utils.getTophatDomain(admin + 1), admin >> 224);
+        assertEq(utils.getTophatDomain(1), 0);
+        assertEq(utils.getTophatDomain(admin - 1), 0);
+    }
+}


### PR DESCRIPTION
We need to remove loops from these utils. Now that we have more testing, it should be fairly easy to do this quickly