### PR TITLE
check if transfer recipient already wears hat

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -498,6 +498,11 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
             revert NotHatWearer();
         }
 
+        // check if recipient is already wearing hat
+        if (isWearerOfHat(_to, _hatId)) {
+            revert AlreadyWearingHat(_to, _hatId);
+        }
+
         //Adjust balances
         --_balanceOf[_from][_hatId];
         ++_balanceOf[_to][_hatId];

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -91,7 +91,7 @@ contract CreateHatsTest is TestSetup {
 
         // assert admin's lastHatId is incremented
         (, , , , , , uint8 lastHatIdPost, , ) = hats.viewHat(topHatId);
-        (, , , , , , , bool mutable_, ) = hats.viewHat(secondHatId);
+        (, , , , , , , mutable_, ) = hats.viewHat(secondHatId);
         assertEq(lastHatId + 1, lastHatIdPost);
         assertFalse(mutable_);
     }
@@ -121,7 +121,7 @@ contract CreateHatsTest is TestSetup {
             secondHatImageURI
         );
 
-        (, , , , , , , bool mutable_, ) = hats.viewHat(secondHatId);
+        (, , , , , , , mutable_, ) = hats.viewHat(secondHatId);
         assertTrue(mutable_);
     }
 
@@ -833,6 +833,16 @@ contract TransferHatTests is TestSetup2 {
 
         // assert hatSupply is not incremented
         assertEq(hats.hatSupply(secondHatId), hatSupply);
+    }
+
+    function testCannotTransferHatToExistingWearer() public {
+        vm.startPrank(topHatWearer);
+
+        hats.mintHat(secondHatId, thirdWearer);
+
+        vm.expectRevert();
+
+        hats.transferHat(secondHatId, secondWearer, thirdWearer);
     }
 }
 


### PR DESCRIPTION
Adds a check to ensure that `transferHat` does not result in an account having a balance of more than 1 of any given hat