### PR TITLE
Fix transfer to balance bug

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -498,8 +498,11 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
             revert NotHatWearer();
         }
 
-        // check if recipient is already wearing hat
-        if (isWearerOfHat(_to, _hatId)) {
+        // Check if recipient is already wearing hat; also checks storage to maintain balance == 1 invariant
+        // if (isWearerOfHat(_to, _hatId)) {
+        //     revert AlreadyWearingHat(_to, _hatId);
+        // }
+        if (_balanceOf[_to][_hatId] > 0) {
             revert AlreadyWearingHat(_to, _hatId);
         }
 

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -499,9 +499,6 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         }
 
         // Check if recipient is already wearing hat; also checks storage to maintain balance == 1 invariant
-        // if (isWearerOfHat(_to, _hatId)) {
-        //     revert AlreadyWearingHat(_to, _hatId);
-        // }
         if (_balanceOf[_to][_hatId] > 0) {
             revert AlreadyWearingHat(_to, _hatId);
         }

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -844,6 +844,29 @@ contract TransferHatTests is TestSetup2 {
 
         hats.transferHat(secondHatId, secondWearer, thirdWearer);
     }
+
+    function testCannotTransferHatToRevokedWearer() public {
+        vm.startPrank(topHatWearer);
+
+        // mint the hat
+        hats.mintHat(secondHatId, thirdWearer);
+
+        // revoke the hat, but do not burn it
+        // mock calls to eligibility contract to return (eligible = true, standing = true)
+        vm.mockCall(
+            address(_eligibility),
+            abi.encodeWithSignature(
+                "getWearerStatus(address,uint256)",
+                thirdWearer,
+                secondHatId
+            ),
+            abi.encode(false, true)
+        );
+        // transfer should revert
+        vm.expectRevert();
+
+        hats.transferHat(secondHatId, secondWearer, thirdWearer);
+    }
 }
 
 contract EligibilitySetHatsTests is TestSetup2 {


### PR DESCRIPTION
To preserve the invariant that the internal token balance (ie `balanceOf` mapping in storage, not the `balanceOf()` public function) of a given address is never higher than 1, the `transferHat` function should check that the `to` recipient of the hat does not already have an internal token balance of 1.

This PR fixes the bug.