### PR TITLE
feat: Allow trees to be linked from the TopHat

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -638,19 +638,20 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
     }
 
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
-      // TODO: verify no circular linkage
-      // TODO: hardcode
-      uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
-      require(isWearerOfHat(msg.sender, fullTopHatId));
-      // TODO ensure hat is active?
-      linkedTreeAdmins[_topHatId] = _newAdminHat;
+        // TODO: verify no circular linkage
+        // TODO: hardcode
+        uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+        require(isWearerOfHat(msg.sender, fullTopHatId));
+        // TODO ensure hat is active? Or the totalSupply is at least nonzero?:
+        // This check could be run in the frontend instead
+        linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 
     function unlinkTopHatFromTree(uint32 _topHatId) external {
-      uint256 adminHat = linkedTreeAdmins[_topHatId];
-      uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
-      require(isAdminOfHat(msg.sender, fullTopHatId));
-      delete linkedTreeAdmins[_topHatId];
+        uint256 adminHat = linkedTreeAdmins[_topHatId];
+        uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+        require(isAdminOfHat(msg.sender, fullTopHatId));
+        delete linkedTreeAdmins[_topHatId];
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -638,10 +638,11 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
     }
 
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
-        require(noCircularLinkage(_topHatId, _newAdminHat), 'Circular Linkage');
-        require(linkedTreeAdmins[_topHatId] == 0, "Domain Already Linked");
+        if (!noCircularLinkage(_topHatId, _newAdminHat)) revert CircularLinkage();
+        if (linkedTreeAdmins[_topHatId] > 0) revert DomainLinked();
+
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
-        require(isWearerOfHat(msg.sender, fullTopHatId), "Caller Not Wearer");
+        if (!isWearerOfHat(msg.sender, fullTopHatId)) revert NotHatWearer();
         linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -637,6 +637,22 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         emit HatMaxSupplyChanged(_hatId, _newMaxSupply);
     }
 
+    function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
+      // TODO: verify no circular linkage
+      // TODO: hardcode
+      uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+      require(isWearerOfHat(msg.sender, fullTopHatId));
+      // TODO ensure hat is active?
+      linkedTreeAdmins[_topHatId] = _newAdminHat;
+    }
+
+    function unlinkTopHatFromTree(uint32 _topHatId) external {
+      uint256 adminHat = linkedTreeAdmins[_topHatId];
+      uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+      require(isAdminOfHat(msg.sender, fullTopHatId));
+      delete linkedTreeAdmins[_topHatId];
+    }
+
     /*//////////////////////////////////////////////////////////////
                               HATS VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -639,17 +639,14 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
 
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
         require(noCircularLinkage(_topHatId, _newAdminHat), 'Circular Linkage');
-        // TODO: hardcode
-        uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+        uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
         require(isWearerOfHat(msg.sender, fullTopHatId));
-        // TODO ensure hat is active? Or the totalSupply is at least nonzero?:
-        // Maybe this check could be run in the frontend instead
         linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 
     function unlinkTopHatFromTree(uint32 _topHatId) external {
         uint256 adminHat = linkedTreeAdmins[_topHatId];
-        uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
+        uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
         require(isAdminOfHat(msg.sender, fullTopHatId));
         delete linkedTreeAdmins[_topHatId];
     }

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -637,6 +637,10 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         emit HatMaxSupplyChanged(_hatId, _newMaxSupply);
     }
 
+    /// @notice Nest a Tree structure under a parent tree
+    /// @dev The tree root can have at most one link at a given time.
+    /// @param _topHatId The domain of the tophat to link
+    /// @param _newAdminHat The hat that will administer the linked tree
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
         if (!noCircularLinkage(_topHatId, _newAdminHat)) revert CircularLinkage();
         if (linkedTreeAdmins[_topHatId] > 0) revert DomainLinked();
@@ -646,6 +650,9 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 
+    /// @notice Unlink a Tree from the parent tree
+    /// @dev This can only be called by an admin of the tree root
+    /// @param _topHatId The domain of the tophat to unlink
     function unlinkTopHatFromTree(uint32 _topHatId) external {
         uint256 adminHat = linkedTreeAdmins[_topHatId];
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -639,6 +639,7 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
 
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
         require(noCircularLinkage(_topHatId, _newAdminHat), 'Circular Linkage');
+        require(linkedTreeAdmins[_topHatId] == 0, "Domain Already Linked");
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
         require(isWearerOfHat(msg.sender, fullTopHatId));
         linkedTreeAdmins[_topHatId] = _newAdminHat;

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -641,14 +641,16 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         require(noCircularLinkage(_topHatId, _newAdminHat), 'Circular Linkage');
         require(linkedTreeAdmins[_topHatId] == 0, "Domain Already Linked");
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
-        require(isWearerOfHat(msg.sender, fullTopHatId));
+        require(isWearerOfHat(msg.sender, fullTopHatId), "Caller Not Wearer");
         linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 
     function unlinkTopHatFromTree(uint32 _topHatId) external {
         uint256 adminHat = linkedTreeAdmins[_topHatId];
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
-        require(isAdminOfHat(msg.sender, fullTopHatId));
+        if(!isAdminOfHat(msg.sender, fullTopHatId))
+          revert  NotAdmin(msg.sender, _topHatId);
+
         delete linkedTreeAdmins[_topHatId];
     }
 

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -648,6 +648,7 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         uint256 fullTopHatId = uint256(_topHatId) << 224; // (256 - TOPHAT_ADDRESS_SPACE);
         if (!isWearerOfHat(msg.sender, fullTopHatId)) revert NotHatWearer();
         linkedTreeAdmins[_topHatId] = _newAdminHat;
+        emit TopHatLinked(_topHatId, _newAdminHat);
     }
 
     /// @notice Unlink a Tree from the parent tree
@@ -660,6 +661,7 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
           revert  NotAdmin(msg.sender, _topHatId);
 
         delete linkedTreeAdmins[_topHatId];
+        emit TopHatLinked(_topHatId, 0);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -638,12 +638,12 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
     }
 
     function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external {
-        // TODO: verify no circular linkage
+        require(noCircularLinkage(_topHatId, _newAdminHat), 'Circular Linkage');
         // TODO: hardcode
         uint256 fullTopHatId = uint256(_topHatId) << (256 - TOPHAT_ADDRESS_SPACE);
         require(isWearerOfHat(msg.sender, fullTopHatId));
         // TODO ensure hat is active? Or the totalSupply is at least nonzero?:
-        // This check could be run in the frontend instead
+        // Maybe this check could be run in the frontend instead
         linkedTreeAdmins[_topHatId] = _newAdminHat;
     }
 

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -146,7 +146,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @return uint256 The domain
     function getTophatDomain(uint256 _hatId) public view returns (uint256) {
         return
-            getTreeAdminAtLevel(_hatId, 0) >>
+            _hatId >>
             (LOWER_LEVEL_ADDRESS_SPACE * MAX_LEVELS);
     }
 }

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -46,8 +46,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
 
     uint256 internal constant TOPHAT_ADDRESS_SPACE = 32; // 32 bits (4 bytes) of space for tophats, aka the "domain"
     uint256 internal constant LOWER_LEVEL_ADDRESS_SPACE = 16; // 16 bits of space for each of the levels below the tophat
-    uint256 internal constant MAX_LEVELS = // 14 levels below the tophat
-        (256 - TOPHAT_ADDRESS_SPACE) / LOWER_LEVEL_ADDRESS_SPACE;
+    uint256 internal constant MAX_LEVELS = 14; // (256 - TOPHAT_ADDRESS_SPACE) / LOWER_LEVEL_ADDRESS_SPACE;
 
     /// @notice Constructs a valid hat id for a new hat underneath a given admin
     /// @dev Check hats[_admin].lastHatId for the previous hat created underneath _admin

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -150,10 +150,25 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @notice Gets the tophat domain of a given hat
     /// @dev A domain is the identifier for a given hat tree, stored in the first 4 bytes of a hat's id
     /// @param _hatId the id of the hat in question
-    /// @return uint256 The domain
-    function getTophatDomain(uint256 _hatId) public pure returns (uint256) {
+    /// @return uint32 The domain
+    function getTophatDomain(uint256 _hatId) public pure returns (uint32) {
         return
-            _hatId >>
-            (LOWER_LEVEL_ADDRESS_SPACE * MAX_LEVELS);
+            uint32(_hatId >>
+            (LOWER_LEVEL_ADDRESS_SPACE * MAX_LEVELS));
+    }
+
+    /// @notice Checks For any circular linkage of trees
+    /// @param _topHatDomain the 32 bit domain of the tree to be linked
+    /// @param _linkedAdmin the hatId of the potential tree admin
+    /// @return bool circular link has been found
+    function noCircularLinkage(
+      uint32 _topHatDomain,
+      uint256 _linkedAdmin
+    ) public view returns (bool) {
+       if (_linkedAdmin == 0) return true;
+       uint32 adminDomain = getTophatDomain(_linkedAdmin);
+       if (_topHatDomain == adminDomain) return false;
+       uint256 parentAdmin = linkedTreeAdmins[adminDomain];
+      return noCircularLinkage(_topHatDomain, parentAdmin);
     }
 }

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -106,8 +106,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @param _hatId The hat in question
     /// @return bool Whether the hat is a topHat
     function isTopHat(uint256 _hatId) public view returns (bool) {
-      uint32 topHatId = uint32(_hatId >> (256 - TOPHAT_ADDRESS_SPACE));
-      return _hatId > 0 && uint224(_hatId) == 0 && linkedTreeAdmins[topHatId] == 0;
+      return _hatId > 0 && uint224(_hatId) == 0 && linkedTreeAdmins[getTophatDomain(_hatId)] == 0;
     }
 
     /// @notice Gets the hat id of the admin at a given level of a given hat
@@ -121,7 +120,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
         view
         returns (uint256)
     {
-        uint256 linkedTreeAdmin = linkedTreeAdmins[uint32(_hatId >> (256 - TOPHAT_ADDRESS_SPACE))];
+        uint256 linkedTreeAdmin = linkedTreeAdmins[getTophatDomain(_hatId)];
         if (linkedTreeAdmin == 0) return getTreeAdminAtLevel(_hatId, _level);
 
         uint8 localTopHatLevel = getHatLevel(getTreeAdminAtLevel(_hatId, 0));

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -47,7 +47,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     uint256 internal constant TOPHAT_ADDRESS_SPACE = 32; // 32 bits (4 bytes) of space for tophats, aka the "domain"
     uint256 internal constant LOWER_LEVEL_ADDRESS_SPACE = 16; // 16 bits of space for each of the levels below the tophat
     uint256 internal constant MAX_LEVELS = // 14 levels below the tophat
-        (256 - TOPHAT_ADDRESS_SPACE) / LOWER_LEVEL_ADDRESS_SPACE; 
+        (256 - TOPHAT_ADDRESS_SPACE) / LOWER_LEVEL_ADDRESS_SPACE;
 
     /// @notice Constructs a valid hat id for a new hat underneath a given admin
     /// @dev Check hats[_admin].lastHatId for the previous hat created underneath _admin
@@ -78,7 +78,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
 
     /// @notice Identifies the level a given hat in its hat tree
     /// @param _hatId the id of the hat in question
-    /// @return level (0 to MAX_LEVELS)
+    /// @return level (0 to type(uint8).max)
     function getHatLevel(uint256 _hatId) public view returns (uint8) {
         uint256 mask;
         uint256 i;
@@ -107,10 +107,12 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @return bool Whether the hat is a topHat
     function isTopHat(uint256 _hatId) public view returns (bool) {
       uint32 topHatId = uint32(_hatId >> (256 - TOPHAT_ADDRESS_SPACE));
-        return _hatId > 0 && uint224(_hatId) == 0 && linkedTreeAdmins[topHatId] == 0;
+      return _hatId > 0 && uint224(_hatId) == 0 && linkedTreeAdmins[topHatId] == 0;
     }
 
     /// @notice Gets the hat id of the admin at a given level of a given hat
+    /// @dev This function traverses trees by following the linkedTreeAdmin
+    ///       pointer to a hat located in a different tree
     /// @param _hatId the id of the hat in question
     /// @param _level the admin level of interest
     /// @return uint256 The hat id of the resulting admin
@@ -129,6 +131,11 @@ contract HatsIdUtilities is IHatsIdUtilities {
         return getAdminAtLevel(linkedTreeAdmin, _level);
     }
 
+    /// @notice Gets the hat id of the admin at a given level of a given hat
+    ///         local to the tree containing the hat.
+    /// @param _hatId the id of the hat in question
+    /// @param _level the admin level of interest
+    /// @return uint256 The hat id of the resulting admin
     function getTreeAdminAtLevel(uint256 _hatId, uint8 _level)
         public
         pure
@@ -144,7 +151,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @dev A domain is the identifier for a given hat tree, stored in the first 4 bytes of a hat's id
     /// @param _hatId the id of the hat in question
     /// @return uint256 The domain
-    function getTophatDomain(uint256 _hatId) public view returns (uint256) {
+    function getTophatDomain(uint256 _hatId) public pure returns (uint256) {
         return
             _hatId >>
             (LOWER_LEVEL_ADDRESS_SPACE * MAX_LEVELS);

--- a/src/Interfaces/HatsErrors.sol
+++ b/src/Interfaces/HatsErrors.sol
@@ -33,4 +33,6 @@ interface HatsErrors {
     error MaxLevelsReached();
     error Immutable();
     error NewMaxSupplyTooLow();
+    error CircularLinkage();
+    error DomainLinked();
 }

--- a/src/Interfaces/HatsEvents.sol
+++ b/src/Interfaces/HatsEvents.sol
@@ -48,4 +48,6 @@ interface HatsEvents {
     event HatMaxSupplyChanged(uint256 hatId, uint32 newMaxSupply);
 
     event HatImageURIChanged(uint256 hatId, string newImageURI);
+
+    event TopHatLinked(uint32 domain, uint256 newAdmin);
 }

--- a/src/Interfaces/IHats.sol
+++ b/src/Interfaces/IHats.sol
@@ -89,6 +89,10 @@ interface IHats is IHatsIdUtilities, HatsErrors, HatsEvents {
         address _to
     ) external;
 
+    function linkTopHatToTree(uint32 _topHatId, uint256 _newAdminHat) external;
+
+    function unlinkTopHatFromTree(uint32 _topHatId) external;
+
     /*//////////////////////////////////////////////////////////////
                               HATS ADMIN FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/src/Interfaces/IHatsIdUtilities.sol
+++ b/src/Interfaces/IHatsIdUtilities.sol
@@ -21,14 +21,14 @@ interface IHatsIdUtilities {
         pure
         returns (uint256 id);
 
-    function getHatLevel(uint256 _hatId) external pure returns (uint8);
+    function getHatLevel(uint256 _hatId) external view returns (uint8);
 
-    function isTopHat(uint256 _hatId) external pure returns (bool);
+    function isTopHat(uint256 _hatId) external view returns (bool);
 
     function getAdminAtLevel(uint256 _hatId, uint8 _level)
         external
-        pure
+        view
         returns (uint256);
 
-    function getTophatDomain(uint256 _hatId) external pure returns (uint256);
+    function getTophatDomain(uint256 _hatId) external view returns (uint256);
 }

--- a/src/Interfaces/IHatsIdUtilities.sol
+++ b/src/Interfaces/IHatsIdUtilities.sol
@@ -30,5 +30,5 @@ interface IHatsIdUtilities {
         view
         returns (uint256);
 
-    function getTophatDomain(uint256 _hatId) external view returns (uint256);
+    function getTophatDomain(uint256 _hatId) external view returns (uint32);
 }

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1552,6 +1552,8 @@ contract LinkHatsTests is TestSetup2 {
       vm.expectRevert(abi.encodeWithSelector(HatsErrors.NotHatWearer.selector));
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       vm.prank(thirdWearer);
+      vm.expectEmit(true, true, true,true);
+      emit TopHatLinked(secondTopHatDomain, secondHatId);
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       assertFalse(hats.isTopHat(secondTopHatId));
       assertEq(hats.getHatLevel(secondTopHatId), 2);
@@ -1570,6 +1572,8 @@ contract LinkHatsTests is TestSetup2 {
       hats.unlinkTopHatFromTree(secondTopHatDomain);
 
       vm.prank(secondWearer);
+      vm.expectEmit(true, true, true,true);
+      emit TopHatLinked(secondTopHatDomain, 0);
       hats.unlinkTopHatFromTree(secondTopHatDomain);
       assertEq(hats.isTopHat(secondTopHatId), true);
     }

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1537,10 +1537,18 @@ contract LinkHatsTests is TestSetup2 {
       vm.prank(topHatWearer);
       vm.expectRevert(bytes('Circular Linkage'));
       hats.linkTopHatToTree(uint32(topHatId >> 224), secondHatId);
+
+      // test a recursive call
+      vm.prank(thirdWearer);
+      hats.linkTopHatToTree(uint32(secondTopHatId >> 224), secondHatId);
+
+      vm.prank(topHatWearer);
+      vm.expectRevert(bytes('Circular Linkage'));
+      hats.linkTopHatToTree(uint32(topHatId >> 224), secondTopHatId);
     }
 
     function testTreeLinkingAndUnlinking() public {
-      uint32 secondTopHatDomain = uint32(secondTopHatId >> 224);
+      uint32 secondTopHatDomain = hats.getTophatDomain(secondTopHatId);
       vm.expectRevert();
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       vm.prank(thirdWearer);

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1549,13 +1549,22 @@ contract LinkHatsTests is TestSetup2 {
 
     function testTreeLinkingAndUnlinking() public {
       uint32 secondTopHatDomain = hats.getTophatDomain(secondTopHatId);
-      vm.expectRevert();
+      vm.expectRevert(
+        bytes("Caller Not Wearer")
+      );
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       vm.prank(thirdWearer);
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       assertFalse(hats.isTopHat(secondTopHatId));
       assertEq(hats.getHatLevel(secondTopHatId), 2);
-      vm.expectRevert();
+
+      vm.expectRevert(
+            abi.encodeWithSelector(
+                HatsErrors.NotAdmin.selector,
+                address(this),
+                secondTopHatDomain
+            )
+      );
       hats.unlinkTopHatFromTree(secondTopHatDomain);
 
       vm.prank(secondWearer);

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1558,6 +1558,10 @@ contract LinkHatsTests is TestSetup2 {
       assertFalse(hats.isTopHat(secondTopHatId));
       assertEq(hats.getHatLevel(secondTopHatId), 2);
 
+      vm.expectRevert(bytes("Domain Already Linked"));
+      vm.prank(thirdWearer);
+      hats.linkTopHatToTree(secondTopHatDomain, topHatId);
+
       vm.expectRevert(
             abi.encodeWithSelector(
                 HatsErrors.NotAdmin.selector,

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1535,7 +1535,7 @@ contract LinkHatsTests is TestSetup2 {
 
     function testPreventingCircularLinking() public {
       vm.prank(topHatWearer);
-      vm.expectRevert(bytes('Circular Linkage'));
+      vm.expectRevert(abi.encodeWithSelector(HatsErrors.CircularLinkage.selector));
       hats.linkTopHatToTree(uint32(topHatId >> 224), secondHatId);
 
       // test a recursive call
@@ -1543,22 +1543,20 @@ contract LinkHatsTests is TestSetup2 {
       hats.linkTopHatToTree(uint32(secondTopHatId >> 224), secondHatId);
 
       vm.prank(topHatWearer);
-      vm.expectRevert(bytes('Circular Linkage'));
+      vm.expectRevert(abi.encodeWithSelector(HatsErrors.CircularLinkage.selector));
       hats.linkTopHatToTree(uint32(topHatId >> 224), secondTopHatId);
     }
 
     function testTreeLinkingAndUnlinking() public {
       uint32 secondTopHatDomain = hats.getTophatDomain(secondTopHatId);
-      vm.expectRevert(
-        bytes("Caller Not Wearer")
-      );
+      vm.expectRevert(abi.encodeWithSelector(HatsErrors.NotHatWearer.selector));
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       vm.prank(thirdWearer);
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       assertFalse(hats.isTopHat(secondTopHatId));
       assertEq(hats.getHatLevel(secondTopHatId), 2);
 
-      vm.expectRevert(bytes("Domain Already Linked"));
+      vm.expectRevert(abi.encodeWithSelector(HatsErrors.DomainLinked.selector));
       vm.prank(thirdWearer);
       hats.linkTopHatToTree(secondTopHatDomain, topHatId);
 

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1533,8 +1533,16 @@ contract LinkHatsTests is TestSetup2 {
         );
     }
 
+    function testPreventingCircularLinking() public {
+      vm.prank(topHatWearer);
+      vm.expectRevert(bytes('Circular Linkage'));
+      hats.linkTopHatToTree(uint32(topHatId >> 224), secondHatId);
+    }
+
     function testTreeLinkingAndUnlinking() public {
       uint32 secondTopHatDomain = uint32(secondTopHatId >> 224);
+      vm.expectRevert();
+      hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       vm.prank(thirdWearer);
       hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
       assertFalse(hats.isTopHat(secondTopHatId));

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1519,3 +1519,31 @@ contract OverridesHatTests is TestSetup2 {
         console2.log("encoded URI", jsonUri);
     }
 }
+
+contract LinkHatsTests is TestSetup2 {
+    uint256 internal secondTopHatId;
+
+    function setUp() public override {
+        super.setUp();
+
+        secondTopHatId = hats.mintTopHat(
+          thirdWearer,
+          "for linking",
+          "http://www.tophat.com/"
+        );
+    }
+
+    function testTreeLinkingAndUnlinking() public {
+      uint32 secondTopHatDomain = uint32(secondTopHatId >> 224);
+      vm.prank(thirdWearer);
+      hats.linkTopHatToTree(secondTopHatDomain, secondHatId);
+      assertFalse(hats.isTopHat(secondTopHatId));
+      assertEq(hats.getHatLevel(secondTopHatId), 2);
+      vm.expectRevert();
+      hats.unlinkTopHatFromTree(secondTopHatDomain);
+
+      vm.prank(secondWearer);
+      hats.unlinkTopHatFromTree(secondTopHatDomain);
+      assertEq(hats.isTopHat(secondTopHatId), true);
+    }
+}

--- a/test/HatsIdUtils.t.sol
+++ b/test/HatsIdUtils.t.sol
@@ -6,36 +6,37 @@ import "../src/HatsIdUtilities.sol";
 import "./LinkableHatsIdUtilities.sol";
 
 contract LinkedTreeHatIdUtilTests is Test {
-  LinkableHatsIdUtilities utils;
-  error InvalidChildHat();
+    LinkableHatsIdUtilities utils;
 
-  function setUp() public {
-    utils = new LinkableHatsIdUtilities();
-  }
+    error InvalidChildHat();
 
-  function testLinkedHats() public {
-    uint256 admin = 1 << 224;
-    uint32 oldTopHat = 2;
-    uint256 oldTopHatId = uint256(oldTopHat) << 224;
-    uint256 id1 = utils.buildHatId(admin, 1);
-    utils.linkTree(oldTopHat, id1);
-    assertFalse(utils.isTopHat(oldTopHatId));
-    assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
-    assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin);
+    function setUp() public {
+        utils = new LinkableHatsIdUtilities();
+    }
 
-    uint32 admin3 = 3;
-    uint256 admin3Id = uint256(admin3) << 224;
-    uint256 id3 = utils.buildHatId(admin3Id,3);
-    utils.linkTree(1, id3);
-    assertEq(utils.getHatLevel(id1), 3);
-    assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
-    assertEq(utils.getHatLevel(admin), utils.getHatLevel(id3) + 1);
-    assertEq(utils.getHatLevel(admin3Id), 0);
-    assertFalse(utils.isTopHat(admin));
+    function testLinkedHats() public {
+        uint256 admin = 1 << 224;
+        uint32 oldTopHat = 2;
+        uint256 oldTopHatId = uint256(oldTopHat) << 224;
+        uint256 id1 = utils.buildHatId(admin, 1);
+        utils.linkTree(oldTopHat, id1);
+        assertFalse(utils.isTopHat(oldTopHatId));
+        assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
+        assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin);
 
-    assertEq(utils.getAdminAtLevel(id1, 2), admin);
-    assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin3Id);
-  }
+        uint32 admin3 = 3;
+        uint256 admin3Id = uint256(admin3) << 224;
+        uint256 id3 = utils.buildHatId(admin3Id, 3);
+        utils.linkTree(1, id3);
+        assertEq(utils.getHatLevel(id1), 3);
+        assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
+        assertEq(utils.getHatLevel(admin), utils.getHatLevel(id3) + 1);
+        assertEq(utils.getHatLevel(admin3Id), 0);
+        assertFalse(utils.isTopHat(admin));
+
+        assertEq(utils.getAdminAtLevel(id1, 2), admin);
+        assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin3Id);
+    }
 }
 
 contract HatIdUtilTests is Test {

--- a/test/HatsIdUtils.t.sol
+++ b/test/HatsIdUtils.t.sol
@@ -3,6 +3,40 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/HatsIdUtilities.sol";
+import "./LinkableHatsIdUtilities.sol";
+
+contract LinkedTreeHatIdUtilTests is Test {
+  LinkableHatsIdUtilities utils;
+  error InvalidChildHat();
+
+  function setUp() public {
+    utils = new LinkableHatsIdUtilities();
+  }
+
+  function testLinkedHats() public {
+    uint256 admin = 1 << 224;
+    uint32 oldTopHat = 2;
+    uint256 oldTopHatId = uint256(oldTopHat) << 224;
+    uint256 id1 = utils.buildHatId(admin, 1);
+    utils.linkTree(oldTopHat, id1);
+    assertEq(utils.isTopHat(oldTopHatId), false);
+    assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
+    assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin);
+
+    uint32 admin3 = 3;
+    uint256 admin3Id = uint256(admin3) << 224;
+    uint256 id3 = utils.buildHatId(admin3Id,3);
+    utils.linkTree(1, id3);
+    assertEq(utils.getHatLevel(id1), 3);
+    assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
+    assertEq(utils.getHatLevel(admin), utils.getHatLevel(id3) + 1);
+    assertEq(utils.getHatLevel(admin3Id), 0);
+    assertEq(utils.isTopHat(admin), false);
+
+    assertEq(utils.getAdminAtLevel(id1, 2), admin);
+    assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin3Id);
+  }
+}
 
 contract HatIdUtilTests is Test {
     HatsIdUtilities utils;

--- a/test/HatsIdUtils.t.sol
+++ b/test/HatsIdUtils.t.sol
@@ -19,7 +19,7 @@ contract LinkedTreeHatIdUtilTests is Test {
     uint256 oldTopHatId = uint256(oldTopHat) << 224;
     uint256 id1 = utils.buildHatId(admin, 1);
     utils.linkTree(oldTopHat, id1);
-    assertEq(utils.isTopHat(oldTopHatId), false);
+    assertFalse(utils.isTopHat(oldTopHatId));
     assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
     assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin);
 
@@ -31,7 +31,7 @@ contract LinkedTreeHatIdUtilTests is Test {
     assertEq(utils.getHatLevel(oldTopHatId), utils.getHatLevel(id1) + 1);
     assertEq(utils.getHatLevel(admin), utils.getHatLevel(id3) + 1);
     assertEq(utils.getHatLevel(admin3Id), 0);
-    assertEq(utils.isTopHat(admin), false);
+    assertFalse(utils.isTopHat(admin));
 
     assertEq(utils.getAdminAtLevel(id1, 2), admin);
     assertEq(utils.getAdminAtLevel(oldTopHatId, 0), admin3Id);

--- a/test/HatsTestSetup.t.sol
+++ b/test/HatsTestSetup.t.sol
@@ -153,7 +153,7 @@ abstract contract TestSetup is Test, TestVariables {
 
 // in addition to TestSetup, TestSetup2 creates and mints a second hat
 abstract contract TestSetup2 is TestSetup {
-    function setUp() public override {
+    function setUp() virtual public override {
         // expand on TestSetup
         super.setUp();
 

--- a/test/LinkableHatsIdUtilities.sol
+++ b/test/LinkableHatsIdUtilities.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../src/HatsIdUtilities.sol";
+
+contract LinkableHatsIdUtilities is HatsIdUtilities {
+
+  function linkTree(uint32 _topHatId, uint256 _hatId) public {
+    linkedTreeAdmins[_topHatId] = _hatId;
+  }
+}


### PR DESCRIPTION
This feature allows for the following:
- effectively infinitely deep trees (really, limited to 255 levels)
- migrating suborgs into parent orgs without changing hat Ids

A few tasks left:
-  [x] figure out the naming semantics for linked tophats and other naming nuances. Should we just call them "tree roots" when linked?
- [x] Ensure we can deploy the contract with this new feature!
- [x] test the new Hats.sol functions
- [x] Add more compreshensive testing to the HatsIdUtils changes
- [x] Add test for circular linkages and safe depth
