### PR TITLE
add WearerStandingChanged event

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -481,9 +481,9 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         if (_standing == badStandings[_hatId][_wearer]) {
             badStandings[_hatId][_wearer] = !_standing;
             updated = true;
-        }
 
-        // emit WearerStatus(_hatId, _wearer, _eligible, _standing);
+            emit WearerStandingChanged(_hatId, _wearer, _standing);
+        }
     }
 
     function transferHat(

--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -466,10 +466,12 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         bool _eligible,
         bool _standing
     ) internal returns (bool updated) {
-        // always ineligible if in bad standing
-        if (!_eligible || !_standing) {
-            // revoke the Hat by burning it
-            _burn(_wearer, _hatId, 1);
+        // revoke/burn the hat if _wearer has a positive balance
+        if (_balanceOf[_wearer][_hatId] > 0) {
+            // always ineligible if in bad standing
+            if (!_eligible || !_standing) {
+                _burn(_wearer, _hatId, 1);
+            }
         }
 
         // record standing for use by other contracts

--- a/src/Interfaces/HatsEvents.sol
+++ b/src/Interfaces/HatsEvents.sol
@@ -28,12 +28,11 @@ interface HatsEvents {
 
     // event HatRenounced(uint256 hatId, address wearer);
 
-    // event WearerStatus(
-    //     uint256 hatId,
-    //     address wearer,
-    //     bool eligible,
-    //     bool wearerStanding
-    // );
+    event WearerStandingChanged(
+        uint256 hatId,
+        address wearer,
+        bool wearerStanding
+    );
 
     event HatStatusChanged(uint256 hatId, bool newStatus);
 

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -896,10 +896,6 @@ contract EligibilitySetHatsTests is TestSetup2 {
         // confirm second hat is worn by second Wearer
         assertTrue(hats.isWearerOfHat(secondWearer, secondHatId));
 
-        // expectEmit WearerStatus - should be wearing, in good standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, true, true);
-
         // 5-6. do not revoke hat
         vm.prank(address(_eligibility));
         hats.setHatWearerStatus(secondHatId, secondWearer, true, true);
@@ -909,10 +905,6 @@ contract EligibilitySetHatsTests is TestSetup2 {
 
     function testRevokeHatFromIneligibleWearerInGoodStanding() public {
         uint32 hatSupply = hats.hatSupply(secondHatId);
-
-        // expectEmit WearerStatus - should not be wearing, in good standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, false, true);
 
         // 5-8a. revoke hat
         vm.prank(address(_eligibility));
@@ -925,9 +917,9 @@ contract EligibilitySetHatsTests is TestSetup2 {
     }
 
     function testRevokeHatFromIneligibleWearerInBadStanding() public {
-        // expectEmit WearerStatus - should not be wearing, in bad standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, false, false);
+        // expectEmit WearerStandingChanged
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
 
         // 5-8b. revoke hat with bad standing
         vm.prank(address(_eligibility));
@@ -937,9 +929,9 @@ contract EligibilitySetHatsTests is TestSetup2 {
     }
 
     function testRevokeHatFromEligibleWearerInBadStanding() public {
-        // expectEmit WearerStatus - should not be wearing, in bad standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, true, false);
+        // expectEmit WearerStandingChanged
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
 
         // 5-8b. revoke hat with bad standing
         vm.prank(address(_eligibility));
@@ -1000,7 +992,7 @@ contract EligibilitySetHatsTests is TestSetup2 {
     }
 }
 
-contract EligibilityGetHatsTests is TestSetup2 {
+contract EligibilityCheckHatsTests is TestSetup2 {
     function testCannotGetHatWearerStandingNoFunctionInEligibilityContract()
         public
     {
@@ -1018,10 +1010,6 @@ contract EligibilityGetHatsTests is TestSetup2 {
 
         // confirm second hat is worn by second Wearer
         assertTrue(hats.isWearerOfHat(secondWearer, secondHatId));
-
-        // expectEmit WearerStatus - should be wearing, in good standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, true, true);
 
         // mock calls to eligibility contract to return (eligible = true, standing = true)
         vm.mockCall(
@@ -1048,10 +1036,6 @@ contract EligibilityGetHatsTests is TestSetup2 {
     {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
-        // expectEmit WearerStatus - should not be wearing, in good standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, false, true);
-
         // mock calls to eligibility contract to return (eligible = false, standing = true)
         vm.mockCall(
             address(_eligibility),
@@ -1077,9 +1061,9 @@ contract EligibilityGetHatsTests is TestSetup2 {
     {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
-        // expectEmit WearerStatus - should not be wearing, in bad standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, false, false);
+        // expectEmit WearerStandingChanged
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
 
         // mock calls to eligibility contract to return (eligible = false, standing = false)
         vm.mockCall(
@@ -1106,9 +1090,9 @@ contract EligibilityGetHatsTests is TestSetup2 {
     {
         uint32 hatSupply = hats.hatSupply(secondHatId);
 
-        // expectEmit WearerStatus - should not be wearing, in bad standing
-        // vm.expectEmit(false, false, false, true);
-        // emit WearerStatus(secondHatId, secondWearer, true, false);
+        // expectEmit WearerStandingChanged
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
 
         // mock calls to eligibility contract to return (eligible = true, standing = false)
         vm.mockCall(

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -990,6 +990,23 @@ contract EligibilitySetHatsTests is TestSetup2 {
         // assert hatSupply is not incremented
         assertEq(hats.hatSupply(secondHatId), hatSupply);
     }
+
+    function testSetWearerBackInGoodStanding() public {
+        // set to bad standing
+        vm.startPrank(address(_eligibility));
+
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
+
+        hats.setHatWearerStatus(secondHatId, secondWearer, false, false);
+
+        // set back to good standing
+
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, true);
+
+        hats.setHatWearerStatus(secondHatId, secondWearer, false, true);
+    }
 }
 
 contract EligibilityCheckHatsTests is TestSetup2 {
@@ -1112,6 +1129,42 @@ contract EligibilityCheckHatsTests is TestSetup2 {
 
         // assert hatSupply is decremented
         assertEq(hats.hatSupply(secondHatId), --hatSupply);
+    }
+
+    function testCheckWearerBackInGoodStanding() public {
+        // set to bad standing
+        // mock call to eligibility contract to return (eligible = true, standing = false)
+        vm.mockCall(
+            address(_eligibility),
+            abi.encodeWithSignature(
+                "getWearerStatus(address,uint256)",
+                secondWearer,
+                secondHatId
+            ),
+            abi.encode(true, false)
+        );
+
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, false);
+
+        hats.checkHatWearerStatus(secondHatId, secondWearer);
+
+        // set back to good standing
+        // mock call to eligibility contract to return (eligible = true, standing = true)
+        vm.mockCall(
+            address(_eligibility),
+            abi.encodeWithSignature(
+                "getWearerStatus(address,uint256)",
+                secondWearer,
+                secondHatId
+            ),
+            abi.encode(true, true)
+        );
+
+        vm.expectEmit(false, false, false, true);
+        emit WearerStandingChanged(secondHatId, secondWearer, true);
+
+        hats.checkHatWearerStatus(secondHatId, secondWearer);
     }
 }
 


### PR DESCRIPTION
This PR adds a `WearerStandingChanged` event emitted any time a wearer's standing for a given hat is changed.

It also adds a check within `_processHatWearerStatus` to ensure that burning a non-existent hat is not attempted. This is important because its possible for both `eligible` and `standing` values to change for a given wearer even if they are not actually wearing the hat in question.