### PR TITLE
Topo's audit fixes

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -796,7 +796,7 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
 
         // TODO TRST-L-4 - refactor this to remove getHatLevel from the recursive loop
 
-        uint8 adminHatLevel = getHatLevel(_hatId) - 1;
+        uint32 adminHatLevel = getHatLevel(_hatId) - 1;
 
         while (adminHatLevel > 0) {
             if (isWearerOfHat(_user, getAdminAtLevel(_hatId, adminHatLevel))) {
@@ -931,7 +931,7 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         // already checked at `level` above, so we start the loop at `level - 1`
 
         for (uint256 i = level - 1; i > 0;) {
-            id = getAdminAtLevel(_hatId, uint8(i));
+            id = getAdminAtLevel(_hatId, uint32(i));
             hat = _hats[id];
             imageURI = hat.imageURI;
 

--- a/src/HatsIdUtilities.sol
+++ b/src/HatsIdUtilities.sol
@@ -94,7 +94,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @notice Identifies the level a given hat in its hat tree
     /// @param _hatId the id of the hat in question
     /// @return level (0 to type(uint8).max)
-    function getHatLevel(uint256 _hatId) public view returns (uint8) {
+    function getHatLevel(uint256 _hatId) public view returns (uint32) {
         uint256 mask;
         uint256 i;
         for (i = 0; i < MAX_LEVELS;) {
@@ -111,10 +111,10 @@ contract HatsIdUtilities is IHatsIdUtilities {
         uint256 treeAdmin = linkedTreeAdmins[uint32(_hatId >> (256 - TOPHAT_ADDRESS_SPACE))];
 
         if (treeAdmin != 0) {
-            return 1 + uint8(i) + getHatLevel(treeAdmin);
+            return 1 + uint32(i) + getHatLevel(treeAdmin);
         }
 
-        return uint8(i);
+        return uint32(i);
     }
 
     /// @notice Checks whether a hat is a topHat
@@ -131,11 +131,11 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @param _hatId the id of the hat in question
     /// @param _level the admin level of interest
     /// @return uint256 The hat id of the resulting admin
-    function getAdminAtLevel(uint256 _hatId, uint8 _level) public view returns (uint256) {
+    function getAdminAtLevel(uint256 _hatId, uint32 _level) public view returns (uint256) {
         uint256 linkedTreeAdmin = linkedTreeAdmins[getTophatDomain(_hatId)];
         if (linkedTreeAdmin == 0) return getTreeAdminAtLevel(_hatId, _level);
 
-        uint8 localTopHatLevel = getHatLevel(getTreeAdminAtLevel(_hatId, 0));
+        uint32 localTopHatLevel = getHatLevel(getTreeAdminAtLevel(_hatId, 0));
 
         if (localTopHatLevel <= _level) return getTreeAdminAtLevel(_hatId, _level - localTopHatLevel);
 
@@ -147,7 +147,7 @@ contract HatsIdUtilities is IHatsIdUtilities {
     /// @param _hatId the id of the hat in question
     /// @param _level the admin level of interest
     /// @return uint256 The hat id of the resulting admin
-    function getTreeAdminAtLevel(uint256 _hatId, uint8 _level) public pure returns (uint256) {
+    function getTreeAdminAtLevel(uint256 _hatId, uint32 _level) public pure returns (uint256) {
         uint256 mask = type(uint256).max << (LOWER_LEVEL_ADDRESS_SPACE * (MAX_LEVELS - _level));
 
         return _hatId & mask;

--- a/src/Interfaces/IHatsIdUtilities.sol
+++ b/src/Interfaces/IHatsIdUtilities.sol
@@ -19,13 +19,13 @@ pragma solidity >=0.8.13;
 interface IHatsIdUtilities {
     function buildHatId(uint256 _admin, uint16 _newHat) external pure returns (uint256 id);
 
-    function getHatLevel(uint256 _hatId) external view returns (uint8);
+    function getHatLevel(uint256 _hatId) external view returns (uint32);
 
     function isTopHat(uint256 _hatId) external view returns (bool);
 
-    function getAdminAtLevel(uint256 _hatId, uint8 _level) external view returns (uint256);
+    function getAdminAtLevel(uint256 _hatId, uint32 _level) external view returns (uint256);
 
-    function getTreeAdminAtLevel(uint256 _hatId, uint8 _level) external pure returns (uint256);
+    function getTreeAdminAtLevel(uint256 _hatId, uint32 _level) external pure returns (uint256);
 
     function getTophatDomain(uint256 _hatId) external view returns (uint32);
 


### PR DESCRIPTION
* Fix: M-3 tree depth overflow

Rather than adding any checks, it's just cheaper to accomodate more depth. This is relatively arbitrary imo. I chose uint8 because I had a hard time imagining any org reaching that size on V1, but breaking for such a silly reason, is poor form, unless we add explicit contraints for nested tree depth.