### PR TITLE
57 - disable mints and transfers of inactive hats

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -241,20 +241,17 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
     function mintHat(uint256 _hatId, address _wearer) public returns (bool success) {
         Hat storage hat = _hats[_hatId];
         if (hat.maxSupply == 0) revert HatDoesNotExist(_hatId);
-
+        // only eligible wearers can receive minted hats
         if (!isEligible(_wearer, _hatId)) revert NotEligible();
-
-        // only the wearer of a hat's admin Hat can mint it
+        // only active hats can be minted
+        if (!_isActive(hat, _hatId)) revert HatNotActive();
+        // only the wearer of one of a hat's admins can mint it
         _checkAdmin(_hatId);
-
-        if (hat.supply >= hat.maxSupply) {
-            revert AllHatsWorn(_hatId);
-        }
-
-        if (_staticBalanceOf(_wearer, _hatId) > 0) {
-            revert AlreadyWearingHat(_wearer, _hatId);
-        }
-
+        // hat supply cannot exceed maxSupply
+        if (hat.supply >= hat.maxSupply) revert AllHatsWorn(_hatId);
+        // wearers cannot wear the same hat more than once
+        if (_staticBalanceOf(_wearer, _hatId) > 0) revert AlreadyWearingHat(_wearer, _hatId);
+        // if we've made it through all the checks, mint the hat
         _mintHat(_wearer, _hatId);
 
         success = true;
@@ -537,28 +534,22 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
     /// @param _to The new wearer
     function transferHat(uint256 _hatId, address _from, address _to) public {
         _checkAdmin(_hatId);
-
         // cannot transfer immutable hats, except for tophats, which can always transfer themselves
         if (!isTopHat(_hatId)) {
             if (!_isMutable(_hats[_hatId])) revert Immutable();
         }
-
         // Checks storage instead of `isWearerOfHat` since admins may want to transfer revoked Hats to new wearers
-        if (_staticBalanceOf(_from, _hatId) < 1) {
-            revert NotHatWearer();
-        }
-
+        if (_staticBalanceOf(_from, _hatId) < 1) revert NotHatWearer();
         // Check if recipient is already wearing hat; also checks storage to maintain balance == 1 invariant
-        if (_staticBalanceOf(_to, _hatId) > 0) {
-            revert AlreadyWearingHat(_to, _hatId);
-        }
-
+        if (_staticBalanceOf(_to, _hatId) > 0) revert AlreadyWearingHat(_to, _hatId);
+        // only eligible wearers can receive transferred hats
         if (!isEligible(_to, _hatId)) revert NotEligible();
-
-        //Adjust balances
+        // only active hats can be transferred
+        if (!_isActive(_hats[_hatId], _hatId)) revert HatNotActive();
+        // we've made it passed all the checks, so adjust balances to execute the transfer
         _balanceOf[_from][_hatId] = 0;
         _balanceOf[_to][_hatId] = 1;
-
+        // emit the ERC1155 standard transfer event
         emit TransferSingle(msg.sender, _from, _to, _hatId, 1);
     }
 

--- a/src/Interfaces/HatsErrors.sol
+++ b/src/Interfaces/HatsErrors.sol
@@ -39,6 +39,9 @@ interface HatsErrors {
     /// @notice Emitted when attempting to mint a non-existant hat
     error HatDoesNotExist(uint256 hatId);
 
+    /// @notice Emmitted when attempting to mint or transfer a hat that is not active
+    error HatNotActive();
+
     /// @notice Emitted when attempting to mint or transfer a hat to an ineligible wearer
     error NotEligible();
 

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -530,25 +530,6 @@ contract MintHatsTest is TestSetup {
         assertEq(hats.hatSupply(secondHatId), supply_pre + 2);
     }
 
-    function testMintInactiveHat() public {
-        // capture pre-values
-        uint256 hatSupply_pre = hats.hatSupply(secondHatId);
-
-        // deactivate the hat
-        vm.prank(_toggle);
-        hats.setHatStatus(secondHatId, false);
-
-        // mint the hat to wearer
-        vm.prank(topHatWearer);
-        hats.mintHat(secondHatId, secondWearer);
-
-        // assert that the wearer does not have the hat
-        assertFalse(hats.isWearerOfHat(secondWearer, secondHatId));
-
-        // assert that the hat supply increased
-        assertEq(++hatSupply_pre, hats.hatSupply(secondHatId));
-    }
-
     function testCannotMintNonExistentHat() public {
         vm.prank(topHatWearer);
 
@@ -568,6 +549,16 @@ contract MintHatsTest is TestSetup {
 
         vm.expectRevert(HatsErrors.NotEligible.selector);
         vm.prank(topHatWearer);
+        hats.mintHat(secondHatId, secondWearer);
+    }
+
+    function testCannotMintInactiveHat() public {
+        // mock a toggle call to return inactive
+        vm.mockCall(address(_toggle), abi.encodeWithSignature("getHatStatus(uint256)", secondHatId), abi.encode(false));
+
+        vm.prank(topHatWearer);
+        // expect hat not active error
+        vm.expectRevert(HatsErrors.HatNotActive.selector);
         hats.mintHat(secondHatId, secondWearer);
     }
 
@@ -755,6 +746,14 @@ contract TransferHatTests is TestSetupMutable {
         );
 
         vm.expectRevert(HatsErrors.NotEligible.selector);
+        vm.prank(topHatWearer);
+        hats.transferHat(secondHatId, secondWearer, thirdWearer);
+    }
+
+    function testCannotTransferInactiveHat() public {
+        vm.mockCall(_toggle, abi.encodeWithSignature("getHatStatus(uint256)", secondHatId), abi.encode(false));
+
+        vm.expectRevert(HatsErrors.HatNotActive.selector);
         vm.prank(topHatWearer);
         hats.transferHat(secondHatId, secondWearer, thirdWearer);
     }
@@ -1013,13 +1012,17 @@ contract RenounceHatsTest is TestSetup2 {
     }
 
     function testCanRenounceHatAsNonWearerWithStaticBalance() public {
-        // hat gets toggled off
-        // encode mock for function inside toggle contract to return false
-        vm.mockCall(address(_toggle), abi.encodeWithSignature("getHatStatus(uint256)", secondHatId), abi.encode(false));
+        // wearer becomes ineligible
+        // encode mock for function inside eligibility contract to return false (inelible), true (good standing)
+        vm.mockCall(
+            _eligibility,
+            abi.encodeWithSignature("getWearerStatus(address,uint256)", secondWearer, secondHatId),
+            abi.encode(false, true)
+        );
 
         // show that admin can't mint again to secondWearer, ie because they have a static balance
         vm.prank(topHatWearer);
-        vm.expectRevert(abi.encodeWithSelector(HatsErrors.AlreadyWearingHat.selector, secondWearer, secondHatId));
+        vm.expectRevert(abi.encodeWithSelector(HatsErrors.NotEligible.selector));
         hats.mintHat(secondHatId, secondWearer);
         assertFalse(hats.isWearerOfHat(secondWearer, secondHatId));
 
@@ -1027,7 +1030,8 @@ contract RenounceHatsTest is TestSetup2 {
         vm.prank(address(secondWearer));
         hats.renounceHat(secondHatId);
 
-        // now, admin should be able to mint again
+        // now, admin should be able to mint again if eligibility no longer returns false
+        vm.clearMockedCalls();
         vm.prank(topHatWearer);
         hats.mintHat(secondHatId, secondWearer);
     }
@@ -1099,7 +1103,7 @@ contract ToggleSetHatsTest is TestSetup2 {
         // artificially mint again to secondWearer
         vm.prank(topHatWearer);
 
-        vm.expectRevert(abi.encodeWithSelector(HatsErrors.AlreadyWearingHat.selector, secondWearer, secondHatId));
+        vm.expectRevert(abi.encodeWithSelector(HatsErrors.HatNotActive.selector));
 
         hats.mintHat(secondHatId, secondWearer);
 
@@ -1164,7 +1168,7 @@ contract ToggleCheckHatsTest is TestSetup2 {
         // artificially mint again to secondWearer
         vm.prank(topHatWearer);
 
-        vm.expectRevert(abi.encodeWithSelector(HatsErrors.AlreadyWearingHat.selector, secondWearer, secondHatId));
+        vm.expectRevert(abi.encodeWithSelector(HatsErrors.HatNotActive.selector));
 
         hats.mintHat(secondHatId, secondWearer);
 


### PR DESCRIPTION
https://github.com/sherlock-audit/2023-02-hats-judging/issues/57