### PR TITLE
3 - remove ERC1155 from `supportsInterface()`

### DIFF
--- a/src/Hats.sol
+++ b/src/Hats.sol
@@ -1215,6 +1215,20 @@ contract Hats is IHats, ERC1155, HatsIdUtilities {
         revert();
     }
 
+    /**
+     * @notice ERC165 interface detection
+     *  @dev While Hats Protocol conforms to the ERC1155 *interface*, it does not fully conform to the ERC1155 *specification*
+     *  since it does not implement the ERC1155Receiver functionality.
+     *  For this reason, this function overrides the ERC1155 implementation to return false for ERC1155.
+     *  @param interfaceId The interface identifier, as specified in ERC-165
+     *  @return bool True if the contract implements `interfaceId` and false otherwise
+     */
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == 0x01ffc9a7 // ERC165 Interface ID for ERC165
+            // interfaceId == 0xd9b67a26 || // ERC165 Interface ID for ERC1155
+            || interfaceId == 0x0e89341c; // ERC165 Interface ID for ERC1155MetadataURI
+    }
+
     /// @notice View the uri for a Hat
     /// @param id The id of the Hat
     /// @return _uri An 1155-compatible JSON object

--- a/test/Hats.t.sol
+++ b/test/Hats.t.sol
@@ -1470,6 +1470,15 @@ contract OverridesHatTests is TestSetup2 {
         console2.log("encoded URI", jsonUri);
     }
 
+    function testSupportsInterface() public {
+        bytes4 ERC165 = 0x01ffc9a7;
+        bytes4 ERC1155Metadata = 0x0e89341c;
+        bytes4 ERC1155Standard = 0xd9b67a26;
+        assertTrue(hats.supportsInterface(ERC165));
+        assertTrue(hats.supportsInterface(ERC1155Metadata));
+        assertFalse(hats.supportsInterface(ERC1155Standard));
+    }
+
     function testCreateUriForTopHat() public view {
         string memory jsonUri = hats.uri(topHatId);
         console2.log("encoded URI", jsonUri);


### PR DESCRIPTION
https://github.com/sherlock-audit/2023-02-hats-judging/issues/3