### PR TITLE
fix: link to audits directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For information on Hats Protocol versions and deployments, see [Releases](https:
 
 ### Security Audits
 
-This project has received the following security audits. See the [audits](https://github.com/Hats-Protocol/hats-protocol/audits) directory for the detailed reports.
+This project has received the following security audits. See the [audits](https://github.com/Hats-Protocol/hats-protocol/tree/main/audits) directory for the detailed reports.
 
 * Trust Security (also includes review of the [HatsSignerGate](https://github.com/Hats-Protocol/hats-zodiac) contracts)
 


### PR DESCRIPTION
Fixed the link to the audits directory in README file.