### PR TITLE
chore: update forge book config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -23,7 +23,7 @@ quote_style = "double"
 tab_width = 4
 wrap_comments = false
 
-[book]
+[profile.book]
 book = "./book.toml"
 
 [rpc_endpoints]


### PR DESCRIPTION
I forked the repo, cloned the repo, ran `forge build`, then got this:
```
warning: Unknown section [book] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.book] instead or run `forge config --fix`.
```
<img width="714" alt="Screenshot 2023-11-15 at 11 17 47 AM" src="https://github.com/Hats-Protocol/hats-protocol/assets/27874039/c322e842-a29a-4a11-8eeb-0a0c394bb712">

So I ran `forge config --fix` like it told me to, and that's the only change in this PR!